### PR TITLE
Fix JWT Extraction from Crystal ZRA Authentication Response

### DIFF
--- a/ca_erpnext_zra/ca_erpnext_zra/apis/auth.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/apis/auth.py
@@ -21,7 +21,7 @@ def authenticate(settings_name: str):
        
 
         token_details = ZRAAuthService.authenticate(
-            auth_server_url, username, password, settings_name
+            auth_server_url, username, password,
         )
         if not token_details:
             return None

--- a/ca_erpnext_zra/ca_erpnext_zra/services/auth_service.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/services/auth_service.py
@@ -62,8 +62,15 @@ class ZRAAuthService:
                 frappe.db.set_value("Integration Request", integration_request.name, "status", "Completed", update_modified=False)
                 expires_in = (data.get("expires_in") or 3600)
                 expiry_time = datetime.now() + timedelta(seconds=int(expires_in))
+                #Extract token correctly from "Result"
+                result = data.get("Result", {}) or {}
+                jwt = result.get("token")
+
+                if not jwt:
+                    frappe.throw("Authentication failed: No token found in response under 'Result'")
+
                 return {
-                "jwt": data.get("token"),
+                "jwt": jwt,
                     "expires_in": int(expires_in),
                     "expiry_time": expiry_time.strftime("%Y-%m-%d %H:%M:%S"),            }
             error = response.json().get("error", "Unknown error") if response.headers.get("content-type", "").startswith("application/json") else "Invalid response"


### PR DESCRIPTION

## Description
This PR resolves a critical issue in the **Crystal VSDC** authentication flow, where the JWT token was not being correctly parsed due to being nested inside the `Result` object in the API response.

The fix ensures proper extraction, validation, and storage of the JWT, enabling subsequent authenticated API calls to succeed.

---

## Changes Included
- Updated `ZRAAuthService.authenticate()` to extract token from `data["Result"]["token"]`
- Improved error handling for missing or malformed responses

---


## Impact
This fix restores full authentication capability with the **Crystal VSDC API**, ensuring smooth integration and preventing token-related failures across all VSDC API calls.
