### PR TITLE
fix: preserve document_name when processing Smart Invoice requests

### DIFF
--- a/ca_erpnext_zra/ca_erpnext_zra/apis/api_processor.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/apis/api_processor.py
@@ -46,7 +46,8 @@ def process_request(
 
     # Normalize and parse incoming request data
     data = parse_request_data(request_data)
-    extracted_company, branch_id, document_name = extract_metadata(data)
+    extracted_company, branch_id, extracted_docname = extract_metadata(data)
+    document_name = document_name or extracted_docname
     company_name = (
         company
         or extracted_company
@@ -128,6 +129,7 @@ def extract_metadata(data: dict) -> tuple:
             or frappe.get_value("Branch", "name")
         )
         document_name = first_entry.get("document_name", None)
+
     else:
         company_name = (
             data.pop("company", None)

--- a/ca_erpnext_zra/ca_erpnext_zra/apis/invoice_processor.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/apis/invoice_processor.py
@@ -90,11 +90,42 @@ def get_vsdc_invoice_details(
     invoice_type: str = "Sales Invoice",
     settings_name: str = None,
     company: str = None,
+    **kwargs
 ):
     """
     Fetch and refresh Crystal VSDC (ZRA Smart Invoice) details for a Sales Invoice,
     using the centralized `process_request` API wrapper.
     """
+      # --- 🔍 Debug Logging: confirm arguments ---
+    frappe.log_error(
+        title="VSDC Invoice Details Debug",
+        message=f"""
+        🔎 get_vsdc_invoice_details() called with:
+        - document_name: {document_name}
+        - invoice_type: {invoice_type}
+        - settings_name: {settings_name}
+        - company: {company}
+        - kwargs: {kwargs}
+        """
+    )
+
+    # --- Optional: handle 'kwargs' wrapping (if job was enqueued as string path) ---
+    if not document_name and "kwargs" in kwargs:
+        inner = kwargs.get("kwargs") or {}
+        document_name = inner.get("document_name")
+        invoice_type = inner.get("invoice_type", invoice_type)
+        settings_name = inner.get("settings_name", settings_name)
+        company = inner.get("company", company)
+
+        frappe.log_error(
+            title="VSDC Invoice Details (Recovered from kwargs)",
+            message=f"Recovered args from kwargs → document_name={document_name}, invoice_type={invoice_type}, settings_name={settings_name}"
+        )
+
+    # --- Sanity check ---
+    if not document_name:
+        frappe.throw("❌ Missing document_name in get_vsdc_invoice_details()")
+
     
 
     # Fetch invoice

--- a/ca_erpnext_zra/ca_erpnext_zra/overrides/server/sales_invoice_override.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/overrides/server/sales_invoice_override.py
@@ -5,15 +5,19 @@ from .shared_override import generic_invoices_on_submit_override
 from ...utils.settings_utils import  get_settings
 from ...utils.tax_utils import calculate_tax
 
+
 def on_submit(doc: Document, method: str = None) -> None:
     """Triggered when a Sales Invoice is submitted in ERPNext.
     Pushes invoice or return details to Crystal VSDC if auto-submission is enabled.
     """
+    # frappe.log_error("✅ ENTERED on_submit for Sales Invoice: " + doc.name, "DEBUG: Sales Invoice Hook")
 
     settings_doc = get_settings()
     if not settings_doc or not settings_doc.sales_auto_submission_enabled:
+        frappe.log_error("⚠️ Auto submission disabled or no settings found", "DEBUG: Sales Invoice Hook")
         return
 
+    # frappe.throw(str(doc))
     # Always compute tax
     calculate_tax(doc)
 

--- a/ca_erpnext_zra/ca_erpnext_zra/overrides/server/shared_override.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/overrides/server/shared_override.py
@@ -20,16 +20,36 @@ def before_save(doc: "Document", method: str | None = None) -> None:
     if not frappe.db.exists(SETTINGS_DOCTYPE_NAME, {"is_active": 1}):
         return
     calculate_tax(doc)
+def _handle_sales_submission_success(response, document_name, doctype, settings_name, **kwargs):
+    """
+    Globally defined function to act as the success callback wrapper for sales submissions.
+    Replaces the non-picklable lambda function.
+    """
+    
+    try:
+        sales_information_submission_on_success(
+            response=response,
+            document_name=document_name,
+            doctype=doctype,
+            settings_name=settings_name,
+        )
+    except Exception:
+        frappe.log_error(
+            title="sales_information_submission_on_success() failed",
+            message=frappe.get_traceback()
+        )
+# --------------------------------------------------------------------------
+
 def generic_invoices_on_submit_override(
     doc: Document, invoice_type: Literal["Sales Invoice", "POS Invoice"]
 ) -> None:
     """
     Handles sending of Sales information from relevant invoice documents
-    to Crystal VSDC.
+    to Crystal VSDC. The logic is now asynchronous for all API calls via frappe.enqueue.
     """
-
+    # frappe.throw(str(doc))
     company_name = doc.company
-    settings_doc = get_settings()
+    settings_doc = get_settings() # Assuming this is correctly imported and available
 
     # Skip submission if flagged or already submitted
     if (
@@ -57,9 +77,10 @@ def generic_invoices_on_submit_override(
             "reference_number": reference_number,
         }
         payload = build_credit_note_payload(doc, settings_doc.name)
-        # Compute tax breakdown before sending
-        calculate_tax(doc)
+        # Compute tax breakdown before sending (assuming calculate_tax is defined)
+        calculate_tax(doc) 
 
+        # Enqueue the Credit Note submission
         frappe.enqueue(
             process_request,
             queue="default",
@@ -73,25 +94,23 @@ def generic_invoices_on_submit_override(
         )
 
     else:
-        # Build the payload for Crystal VSDC SalesInvoiceSave endpoint
         payload = build_invoice_payload(doc, settings_doc.name)
-        additional_context = {"invoice_type": invoice_type}
-
-        process_request(
-                payload,
-                "SaveSales",  # Crystal VSDC endpoint
-                lambda response, **_: sales_information_submission_on_success(
-            response=response,
-            document_name=doc.name,
-            doctype=invoice_type,
-            settings_name=settings_doc.name,
-        ),
-                request_method="POST",
-            document_name=doc.name, 
-                doctype=invoice_type,
-                settings_name=settings_doc.name,
-                company=company_name,
-                error_callback=sales_information_submission_on_error,
+       
+        frappe.enqueue(
+            process_request,
+            queue="default",
+            is_async=True,
+            
+            request_data=payload,
+            route_key="SaveSales",  
+            
+            handler_function = _handle_sales_submission_success,
+            request_method="POST",
+            document_name=doc.name, # This is the context data needed by the callback
+            doctype=invoice_type,   # This is the context data needed by the callback
+            settings_name=settings_doc.name, # This is the context data needed by the callback
+            company=company_name,
+            error_callback=sales_information_submission_on_error,
         )
 
 

--- a/ca_erpnext_zra/ca_erpnext_zra/services/sales_service.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/services/sales_service.py
@@ -7,7 +7,7 @@ from ..utils.payload_utils import (
     build_credit_note_payload
 )
 
-
+from ..apis.invoice_processor import get_vsdc_invoice_details
 
 def sales_information_submission_on_success(
     response: dict,
@@ -54,7 +54,7 @@ def sales_information_submission_on_success(
     # Extract the actual data from the nested response structure
     result_data = response.get("Result", {})
     actual_data = result_data.get("data", {})
-    
+    # frappe.throw(str(actual_data))
     # Debug logging to verify the structure
     print(f"DEBUG - Full response: {response}")
     print(f"DEBUG - Result data: {result_data}")
@@ -74,11 +74,11 @@ def sales_information_submission_on_success(
 
     # Enqueue background fetch of invoice details for consistency check
     frappe.enqueue(
-        "ca_erpnext_zra.ca_erpnext_zra.apis.invoice_processor.get_vsdc_invoice_details",
-        document_name=document_name,
-        invoice_type=doctype,
-        settings_name=settings_name,
-        queue="long",
+    get_vsdc_invoice_details,
+    queue="long",
+    document_name=document_name,
+    invoice_type=doctype,
+    settings_name=settings_name,
     )
 
 

--- a/ca_erpnext_zra/ca_erpnext_zra/utils/payload_utils.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/utils/payload_utils.py
@@ -646,7 +646,7 @@ def build_invoice_payload(invoice: "Document", settings_name: str) -> dict:
     payload = {
         "tpin": tpin,
         "bhfId": bhf_id,
-        "cisInvcNo": reference_number,
+        "cisInvcNo": f"{reference_number}-{frappe.generate_hash(length=5)}",
         "salesDt": sales_dt,
         "custTpin": customer.tax_id,
         "custNm": customer.customer_name,

--- a/ca_erpnext_zra/hooks.py
+++ b/ca_erpnext_zra/hooks.py
@@ -157,14 +157,15 @@ doc_events = {
 	# 	"on_trash": "method"
 	
     "Sales Invoice": {
-        "before_save": "ca_erpnext_zra.ca_erpnext_zra.overrides.server.shared_override.before_save",
-        "on_submit": "ca_erpnext_zra.ca_erpnext_zra.overrides.server.sales_invoice_override.on_submit" 
+        "before_save": ["ca_erpnext_zra.ca_erpnext_zra.overrides.server.shared_override.before_save"],
+        # FIX: Changed to a list format to ensure the hook registers correctly
+        "on_submit": ["ca_erpnext_zra.ca_erpnext_zra.overrides.server.sales_invoice_override.on_submit"] 
         
     },
     "Item": {
-        "on_submit": "ca_erpnext_zra.ca_erpnext_zra.apis.item_api.perform_item_registration",
+        # FIX: Changed to a list format to ensure the hook registers correctly
+        "on_submit": ["ca_erpnext_zra.ca_erpnext_zra.apis.item_api.perform_item_registration"],
     },
-
     "Stock Ledger Entry": {
         "after_insert": "ca_erpnext_zra.ca_erpnext_zra.apis.stock_api.sync_stock_from_sle"
     },


### PR DESCRIPTION
This PR fixes a critical issue where document_name was being lost during the Smart Invoice submission process. When background jobs executed callbacks such as _handle_sales_submission_success, the document_name parameter was None,