### PR TITLE
feat: implement import items workflow with item, supplier, and invoice creation

### DIFF
--- a/ca_erpnext_zra/ca_erpnext_zra/apis/import_item.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/apis/import_item.py
@@ -2,10 +2,11 @@ import json
 from datetime import datetime
 
 import frappe
+from frappe.model.document import Document
 from frappe.utils import add_to_date
 
 from ..apis.api_processor import process_request
-from ..doctype.doctype_names_mapping import SETTINGS_DOCTYPE_NAME
+from ..doctype.doctype_names_mapping import SETTINGS_DOCTYPE_NAME, COUNTRY_DOCTYPE_NAME
 from ..handlers.import_item_handler import imported_items_select_on_success
 from ..utils.payload_utils import build_import_item_payload
 from ..utils.routes_utils import get_route_path
@@ -41,3 +42,47 @@ def perform_import_item(request_data: str, settings_name: str, route_key: str):
 		doctype="Item",
 		settings_name=settings_name,
 	)
+
+
+@frappe.whitelist()
+def create_items_from_fetched_registered_imports(request_data: str) -> None:
+	data = json.loads(request_data)
+	if data["items"]:
+		items = data["items"]
+		for item in items:
+			get_or_create_item(item)
+
+
+def get_or_create_item(data: dict) -> Document:
+	if frappe.db.exists("Item", {"item_code": data["item_name"]}):
+		return frappe.get_doc("Item", {"item_code": data["item_name"]})
+	else:
+		new_item = frappe.new_doc("Item")
+		new_item.is_stock_item = 0  # Default to 0
+		new_item.item_code = data["item_name"]
+		new_item.item_name = data["item_name"]
+		new_item.item_group = "All Item Groups"
+		new_item.custom_smart_packaging_unit = data["packaging_unit_code"]
+		new_item.custom_smart_quantity_unit = data["quantity_unit_code"]
+		new_item.custom_hs_code = data["hs_code"]
+		new_item.custom_imported_item_task_code = data["task_code"]
+		# new_item.custom_unit_of_quantity = data.get("quantity_unit_code", None) or data["unit_of_quantity_code"]
+		# item_code = data.get("item_code", None)
+		new_item.custom_smart_country_of_origin_ = data["origin_nation_code"]
+		new_item.custom_smart_country_of_origin_name = (
+			frappe.get_doc(
+				COUNTRY_DOCTYPE_NAME,
+				{"code": data["origin_nation_code"]},
+				for_update=False,
+			).code_name
+			if data["origin_nation_code"]
+			else None
+		)
+		new_item.valuation_rate = data["unit_price"]
+
+		if "imported_item" in data:
+			new_item.is_stock_item = 1
+			new_item.custom_referenced_imported_item = data["imported_item"]
+
+		new_item.insert(ignore_mandatory=True, ignore_if_duplicate=True)
+		return new_item

--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.js
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.js
@@ -1,8 +1,144 @@
 // Copyright (c) 2025, Crystalised Apps and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Crystallised Smart Registered Import Item", {
-// 	refresh(frm) {
+const doctypeName = "Crystallised Smart Registered Import Item";
 
-// 	},
-// });
+frappe.ui.form.on(doctypeName, {
+	refresh: function (frm) {
+		const companyName = frappe.db.get_value(
+			"Crystal ZRA Smart Invoice Settings",
+			frm.doc.settings,
+			"company_name"
+		);
+		const item = [
+			{
+				item_classification_code: null,
+				taxation_type_code: null,
+				item_code: null,
+				item_name: frm.doc.item_name,
+				packaging_unit_code: frm.doc.packaging_unit_code,
+				quantity_unit_code: frm.doc.quantity_unit_code,
+				unit_price:
+					parseFloat(frm.doc.invoice_foreign_currency_amount) /
+					parseFloat(frm.doc.quantity).toFixed(2),
+				quantity: frm.doc.quantity,
+				imported_item: frm.doc.name,
+				task_code: frm.doc.task_code,
+				origin_nation_code: frm.doc.origin_nation_code,
+				hs_code: frm.doc.hs_code,
+				imported_item_status: frm.doc.imported_item_status,
+				imported_item_status_code: frm.doc.imported_item_status_code,
+			},
+		];
+
+		if (!frm.is_new()) {
+			frm.add_custom_button(
+				__("Create Item"),
+				function () {
+					frappe.call({
+						method: "ca_erpnext_zra.ca_erpnext_zra.apis.import_item.create_items_from_fetched_registered_imports",
+						args: {
+							request_data: {
+								items: item,
+							},
+						},
+						callback: (response) => {
+							frappe.msgprint(
+								"Item has been created. Please go to the created Item and provide required Smart Item Details."
+							);
+						},
+						error: (error) => {
+							// Error Handling is Defered to the Server
+						},
+						freeze: true,
+						freeze_message: __("Creating Item..."),
+					});
+				},
+				__("Smart Actions")
+			);
+
+			frm.add_custom_button(
+				__("Create Supplier"),
+				function () {
+					frappe.call({
+						method: "ca_erpnext_zra.ca_erpnext_zra.utils.create_supplier.create_supplier_from_fetched_registered_import",
+						args: {
+							request_data: {
+								name: frm.doc.name,
+								company_name: companyName,
+								supplier_name: frm.doc.suppliers_name,
+								supplier_pin: null,
+								supplier_currency: frm.doc.invoice_foreign_currency,
+								supplier_nation: frm.doc.origin_nation_code,
+							},
+						},
+						callback: (response) => {
+							frappe.msgprint(
+								__(
+									"Supplier has been created. Please confirm the details captured."
+								)
+							);
+						},
+						error: (error) => {
+							// Error Handling is Defered to the Server
+						},
+						freeze: true,
+						freeze_message: __("Creating Supplier..."),
+					});
+				},
+				__("Smart Actions")
+			);
+
+			frappe.db.get_value(
+				"Item",
+				{ item_code: frm.doc.item_name },
+				["custom_item_registered", "name"],
+				(response) => {
+					if (parseInt(response.custom_item_registered) === 1) {
+						frm.add_custom_button(
+							__("Create Purchase Invoice"),
+							function () {
+								frappe.call({
+									method: "ca_erpnext_zra.ca_erpnext_zra.utils.create_purchase_invoice.create_purchase_invoice_from_request",
+									args: {
+										request_data: {
+											name: frm.doc.name,
+											supplier_invoice_no: null,
+											supplier_invoice_date: null,
+											supplier_name: frm.doc.suppliers_name,
+											supplier_currency: frm.doc.invoice_foreign_currency,
+											supplier_nation: frm.doc.origin_nation_code,
+											supplier_branch_id: null,
+											exchange_rate: frm.doc.foreign_currency_exchange_rate,
+											currency: frm.doc.invoice_foreign_currency,
+											amount: frm.doc.invoice_foreign_currency_amount,
+											items: item,
+											task_code: frm.doc.task_code,
+											company_name: companyName,
+										},
+									},
+									callback: (response) => {
+										frappe.msgprint(
+											"Purchase Invoice has been created. Please go to the created Invoice and provide required eTims Details."
+										);
+									},
+									error: (error) => {
+										// Error Handling is Defered to the Server
+									},
+								});
+							},
+							__("Smart Actions")
+						);
+					} else {
+						frm.set_intro(
+							__(
+								"Item not registered yet. Please register it to allow creation of a Purchase Invoice."
+							),
+							"red"
+						);
+					}
+				}
+			);
+		}
+	},
+});

--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.json
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.json
@@ -1,11 +1,12 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "field:item_name",
+ "autoname": "field:item_identifier",
  "creation": "2025-11-18 10:25:41.119630",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "item_identifier",
   "item_name",
   "origin_nation_code",
   "declaration_date",
@@ -38,8 +39,7 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Item Name",
-   "unique": 1
+   "label": "Item Name"
   },
   {
    "fieldname": "origin_nation_code",
@@ -169,13 +169,24 @@
    "fieldname": "foreign_currency_exchange_rate",
    "fieldtype": "Float",
    "label": "Foreign Currency Exchange Rate"
+  },
+  {
+   "fieldname": "item_identifier",
+   "fieldtype": "Data",
+   "label": "Item Identifier",
+   "unique": 1
   }
  ],
  "grid_page_length": 50,
  "in_create": 1,
  "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2025-11-19 00:58:24.715245",
+ "links": [
+  {
+   "link_doctype": "Item",
+   "link_fieldname": "custom_referenced_imported_item"
+  }
+ ],
+ "modified": "2025-11-20 23:26:11.963298",
  "modified_by": "Administrator",
  "module": "Ca Erpnext Zra",
  "name": "Crystallised Smart Registered Import Item",

--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item_list.js
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item_list.js
@@ -13,6 +13,8 @@ frappe.listview_settings[doctypeName] = {
 				args: { company_name: company },
 				callback: function (r) {},
 				error: function (err) {},
+				freeze: true,
+				freeze_message: __("Fetching Import Items..."),
 			});
 		});
 	},

--- a/ca_erpnext_zra/ca_erpnext_zra/handlers/import_item_handler.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/handlers/import_item_handler.py
@@ -7,7 +7,6 @@ from ..doctype.doctype_names_mapping import (
 	IMPORTED_ITEMS_STATUS_DOCTYPE_NAME,
 	PACKAGING_UNIT_DOCTYPE_NAME,
 	REGISTERED_IMPORTED_ITEM_DOCTYPE_NAME,
-	SMART_CRYSTALLISED_MAPPING_DOCTYPE_NAME,
 	UNIT_OF_QUANTITY_DOCTYPE_NAME,
 )
 from ..utils.smart_api_utils import get_link_value, get_or_create_link
@@ -23,15 +22,19 @@ def imported_items_select_on_success(response: dict, settings_name: str, **kwarg
 
 	for item in items:
 		try:
-			item_name = item.get("itemNm")
+			item_id = f"{item.get('itemSeq')}{item.get('dclDe')}{item.get('taskCd')}"
 			existing_item = frappe.db.get_value(
 				REGISTERED_IMPORTED_ITEM_DOCTYPE_NAME,
-				{"item_name": item_name},
+				{"item_identifier": item_id},
 				"name",
 				order_by="creation desc",
 			)
 
+			if existing_item:
+				continue
+
 			response_data = {
+				"item_identifier": item_id,
 				"item_name": item.get("itemNm"),
 				"task_code": item.get("taskCd"),
 				"declaration_date": parse_date(item.get("dclDe")),
@@ -67,66 +70,86 @@ def imported_items_select_on_success(response: dict, settings_name: str, **kwarg
 				"settings": settings_name,
 			}
 
-			if existing_item:
-				item_doc = frappe.get_doc(REGISTERED_IMPORTED_ITEM_DOCTYPE_NAME, existing_item)
-				item_doc.update(response_data)
-				item_doc.flags.ignore_mandatory = True
-				item_doc.save(ignore_permissions=True)
-			else:
-				item_doc = frappe.get_doc({"doctype": REGISTERED_IMPORTED_ITEM_DOCTYPE_NAME, **response_data})
-				item_doc.insert(ignore_permissions=True, ignore_mandatory=True, ignore_if_duplicate=True)
+			# if existing_item:
+			# 	item_doc = frappe.get_doc(REGISTERED_IMPORTED_ITEM_DOCTYPE_NAME, existing_item)
+			# 	item_doc.update(response_data)
+			# 	item_doc.flags.ignore_mandatory = True
+			# 	item_doc.save(ignore_permissions=True)
+			# else:
+			# 	item_doc = frappe.get_doc({"doctype": REGISTERED_IMPORTED_ITEM_DOCTYPE_NAME, **response_data})
+			# 	item_doc.insert(ignore_permissions=True, ignore_mandatory=True, ignore_if_duplicate=True)
 
-			item_name = item.get("itemNm")
-			if not item_name:
-				continue
+			item_doc = frappe.get_doc({"doctype": REGISTERED_IMPORTED_ITEM_DOCTYPE_NAME, **response_data})
+			item_doc.insert(ignore_permissions=True, ignore_mandatory=True, ignore_if_duplicate=True)
 
-			product_name = None
-			if frappe.db.exists(
-				SMART_CRYSTALLISED_MAPPING_DOCTYPE_NAME,
-				{"zra_item_code": item_name, "smart_setup": settings_name},
-			):
-				product_name = frappe.db.get_value(
-					SMART_CRYSTALLISED_MAPPING_DOCTYPE_NAME,
-					{"zra_item_code": item_name, "smart_setup": settings_name},
-					"parent",
-					order_by="creation desc",
-				)
-				product = frappe.get_doc("Item", product_name)
+			# item_name = item.get("itemNm")
+			# if not item_name:
+			# 	continue
 
-			else:
-				if frappe.db.exists("Item", {"item_code": item_name}):
-					product = frappe.get_doc("Item", {"item_code": item_name})
-				else:
-					product = frappe.new_doc("Item")
-					product.item_name = item_name
-					product.item_code = item_name
-					default_item_group = frappe.get_all(
-						"Item Group", filters={"is_group": 1}, fields=["name"], limit=1
-					)
-					product.item_group = (
-						default_item_group[0].name if default_item_group else "All Item Groups"
-					)
-					product.flags.ignore_mandatory = True
-					product.insert(ignore_permissions=True)
-				frappe.get_doc(
-					{
-						"doctype": SMART_CRYSTALLISED_MAPPING_DOCTYPE_NAME,
-						"parent": product.name,
-						"parenttype": "Item",
-						"parentfield": "custom_smart_setup_mapping",
-						"zra_item_code": item_name,
-						"smart_setup": settings_name,
-					}
-				).insert(ignore_permissions=True)
+			# item_code = f"{item.get('orgnNatCd')}{item.get('pkgUnitCd')}{item.get('qtyUnitCd')}"
+			# item_name = item.get("itemNm")
 
-			update_data = {
-				"custom_referenced_imported_item": item_doc.name,
-				"custom_imported_item_task_code": item_doc.task_code,
-				"custom_hs_code": item_doc.hs_code,
-				"custom_imported_item_status": item_doc.imported_item_status,
-				"custom_imported_item_status_code": item_doc.imported_item_status_code,
-			}
-			frappe.db.set_value("Item", product.name, update_data, update_modified=False)
+			# if frappe.db.exists("Item", {"item_code": item_code}):
+			# 	product = frappe.get_doc("Item", {"item_code": item_code})
+			# else:
+			# 	product = frappe.new_doc("Item")
+			# 	product.item_code = item_code
+			# 	product.item_name = item_name
+			# 	default_item_group = frappe.get_all(
+			# 		"Item Group", filters={"is_group": 1}, fields=["name"], limit=1
+			# 	)
+			# 	product.item_group = default_item_group[0].name if default_item_group else "All Item Groups"
+			# 	product.flags.ignore_mandatory = True
+			# 	product.insert(ignore_permissions=True)
+
+			# product_name = None
+			# if frappe.db.exists(
+			# 	SMART_CRYSTALLISED_MAPPING_DOCTYPE_NAME,
+			# 	{"zra_item_code": item_name, "smart_setup": settings_name},
+			# ):
+			# 	product_name = frappe.db.get_value(
+			# 		SMART_CRYSTALLISED_MAPPING_DOCTYPE_NAME,
+			# 		{"zra_item_code": item_name, "smart_setup": settings_name},
+			# 		"parent",
+			# 		order_by="creation desc",
+			# 	)
+			# 	product = frappe.get_doc("Item", product_name)
+
+			# else:
+			# 	if frappe.db.exists("Item", {"item_code": item_name}):
+			# 		product = frappe.get_doc("Item", {"item_code": item_name})
+			# 	else:
+			# 		product = frappe.new_doc("Item")
+			# 		product.item_name = item_name
+			# 		product.item_code = item_name
+			# 		default_item_group = frappe.get_all(
+			# 			"Item Group", filters={"is_group": 1}, fields=["name"], limit=1
+			# 		)
+			# 		product.item_group = (
+			# 			default_item_group[0].name if default_item_group else "All Item Groups"
+			# 		)
+			# 		product.flags.ignore_mandatory = True
+			# 		product.insert(ignore_permissions=True)
+			# 	frappe.get_doc(
+			# 		{
+			# 			"doctype": SMART_CRYSTALLISED_MAPPING_DOCTYPE_NAME,
+			# 			"parent": product.name,
+			# 			"parenttype": "Item",
+			# 			"parentfield": "custom_smart_setup_mapping",
+			# 			"zra_item_code": item_name,
+			# 			"smart_setup": settings_name,
+			# 		}
+			# 	).insert(ignore_permissions=True)
+
+			# update_data = {
+			# 	"custom_referenced_imported_item": item_doc.name,
+			# 	"custom_imported_item_task_code": item_doc.task_code,
+			# 	"custom_hs_code": item_doc.hs_code,
+			# 	"custom_imported_item_status": item_doc.imported_item_status,
+			# 	"custom_imported_item_status_code": item_doc.imported_item_status_code,
+			# 	"is_stock_item": 1,
+			# }
+			# frappe.db.set_value("Item", product.name, update_data, update_modified=False)
 
 			counter += 1
 			if counter % batch_size == 0:

--- a/ca_erpnext_zra/ca_erpnext_zra/utils/create_purchase_invoice.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/utils/create_purchase_invoice.py
@@ -1,0 +1,99 @@
+import json
+
+import frappe
+from frappe.utils import get_link_to_form
+
+from ..utils.create_supplier import get_or_create_supplier
+from ..apis.import_item import get_or_create_item
+
+
+@frappe.whitelist()
+def create_purchase_invoice_from_request(request_data: str) -> None:
+	data = json.loads(request_data)
+
+	supplier = None
+	if not frappe.db.exists("Supplier", data["supplier_name"]):
+		supplier = get_or_create_supplier(data).name
+
+	all_items = []
+	all_existing_items = {item["name"]: item for item in frappe.db.get_all("Item", ["*"])}
+
+	for received_item in data["items"]:
+		# Check if item exists
+		if received_item["item_name"] not in all_existing_items:
+			created_item = get_or_create_item(received_item)
+			all_items.append(created_item)
+
+	# Create the Purchase Invoice
+	purchase_invoice = frappe.new_doc("Purchase Invoice")
+	purchase_invoice.supplier = supplier or data["supplier_name"]
+	purchase_invoice.update_stock = 1
+	purchase_invoice.bill_no = data["supplier_invoice_no"]
+	purchase_invoice.bill_date = data["supplier_invoice_date"]
+	purchase_invoice.custom_source_registered_purchase = data["name"]
+	if "currency" in data:
+		# The "currency" key is only available when creating from Imported Item
+		purchase_invoice.currency = data["currency"]
+		# purchase_invoice.custom_source_registered_imported_item = data["name"]
+
+	if "exchange_rate" in data:
+		purchase_invoice.conversion_rate = data["exchange_rate"]
+
+	purchase_invoice.set("items", [])
+
+	# # TODO: Remove Hard-coded values
+	# purchase_invoice.custom_purchase_type = "Copy"
+	# purchase_invoice.custom_receipt_type = "Purchase"
+	# purchase_invoice.custom_payment_type = "CASH"
+	# purchase_invoice.custom_purchase_status = "Approved"
+
+	for item in data["items"]:
+		standard_item = frappe.db.get_all("Item", {"item_code": item["item_name"]}, ["*"])[0]
+		purchase_invoice.append(
+			"items",
+			{
+				"item_name": standard_item["item_name"],
+				"item_code": standard_item["item_code"],
+				"qty": item["quantity"],
+				"rate": item["unit_price"],
+				# "expense_account": expense_account,
+				# update this later
+				# "custom_item_classification": standard_item["custom_smart_item_classification_code"] or "",
+				# "custom_packaging_unit": standard_item["custom_smart_packaging_unit"] or "",
+				# "custom_unit_of_quantity": standard_item["custom_smart_quantity_unit"] or "",
+				# # "custom_taxation_type": standard_item["custom_taxation_type"],
+				# "task_code": item["task_code"],
+			},
+		)
+	validate_mapping_and_registration_of_items(data["items"])
+	purchase_invoice.insert(ignore_mandatory=True)
+
+	frappe.msgprint("Purchase Invoices have been created")
+
+
+def validate_mapping_and_registration_of_items(items):
+	for item in items:
+		item_name = item.get("item_name")
+		items = frappe.get_all(
+			"Item",
+			filters={"item_code": item_name},
+			fields=["name", "item_name", "item_code"],
+		)
+		if items:
+			item_name = items[0].name
+
+			validation_message(item_name)
+
+
+def validation_message(item_code):
+	item_doc = frappe.get_doc("Item", item_code)
+
+	if item_doc.custom_referenced_imported_item and (
+		item_doc.custom_item_registered == 0 or item_doc.custom_imported_item_submitted == 0
+	):
+		item_link = get_link_to_form("Item", item_doc.name)
+		frappe.throw(f"Register or submit the item: {item_link}")
+
+	elif not item_doc.custom_referenced_imported_item and item_doc.custom_item_registered == 0:
+		item_link = get_link_to_form("Item", item_doc.name)
+		frappe.throw(f"Register the item: {item_link}")

--- a/ca_erpnext_zra/ca_erpnext_zra/utils/create_supplier.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/utils/create_supplier.py
@@ -1,0 +1,36 @@
+import json
+
+import frappe
+from frappe.model.document import Document
+
+
+@frappe.whitelist()
+def create_supplier_from_fetched_registered_import(request_data: str) -> None:
+	data = json.loads(request_data)
+
+	new_supplier = get_or_create_supplier(data)
+
+	frappe.msgprint(f"Supplier: {new_supplier.name} created successfully.")
+
+
+def get_or_create_supplier(supplier_details: dict) -> Document:
+	if frappe.db.exists("Supplier", {"name": supplier_details["supplier_name"]}):
+		return frappe.get_doc("Supplier", {"name": supplier_details["supplier_name"]})
+	else:
+		new_supplier = frappe.new_doc("Supplier")
+
+		new_supplier.supplier_name = supplier_details["supplier_name"]
+		new_supplier.tax_id = supplier_details["supplier_pin"]
+
+		if "supplier_currency" in supplier_details:
+			new_supplier.default_currency = supplier_details["supplier_currency"]
+
+		if "supplier_nation" in supplier_details:
+			country = frappe.db.get_value(
+				"Country", {"code": supplier_details["supplier_nation"].lower()}, "name"
+			)
+			new_supplier.country = country
+
+		new_supplier.insert(ignore_if_duplicate=True)
+
+		return new_supplier


### PR DESCRIPTION
This commit introduces a complete workflow for managing imported items fetched from ZRA VSDC API, including the ability to create Items, Suppliers, and Purchase Invoices directly from registered import records.

import_item: add item creation from fetched imports
- Add create_items_from_fetched_registered_imports() whitelisted API
- Implement get_or_create_item() helper to create Item documents
- Auto-populate item fields: packaging unit, quantity unit, HS code, task code
- Link items to country of origin with code lookup
- Set valuation rate from unit price
- Mark as stock item when linked to imported item reference
- Import Document type for type hinting

import_handler: implement unique import item identification
- Generate unique item_identifier from itemSeq + dclDe + taskCd
- Skip duplicate imports based on item_identifier
- Remove legacy item mapping and auto-creation logic
- Remove SMART_CRYSTALLISED_MAPPING_DOCTYPE_NAME dependency
- Comment out automatic Item creation to allow manual control
- Prevent duplicate processing of already fetched items

doctype: enhance Registered Import Item with unique identifier
- Add item_identifier field as new autoname field
- Remove unique constraint from item_name to allow duplicates
- Add Item doctype link for custom_referenced_imported_item
- Update field_order to include item_identifier at top
- Change autoname from "field:item_name" to "field:item_identifier"

ui: add Smart Actions for import item processing
- Implement form view with Create Item, Supplier, and Invoice buttons
- Add Create Item action with freeze UI and progress message
- Add Create Supplier action with company and currency support
- Add Create Purchase Invoice action (conditional on item registration)
- Show warning intro when item not yet registered
- Calculate unit_price dynamically from amount and quantity
- Build comprehensive item data structure for all actions
- Group all actions under "Smart Actions" button group

supplier: add supplier creation utility
- Create new create_supplier.py utility module
- Implement create_supplier_from_fetched_registered_import() API
- Add get_or_create_supplier() helper with duplicate checking
- Auto-populate supplier name, tax ID, currency, and country
- Handle optional supplier_currency and supplier_nation fields
- Map country code to Country doctype name

purchase_invoice: add purchase invoice creation utility
- Create new create_purchase_invoice.py utility module
- Implement create_purchase_invoice_from_request() API
- Auto-create missing suppliers before invoice creation
- Auto-create missing items before adding to invoice
- Set invoice fields: supplier, bill info, currency, exchange rate
- Link invoice to source registered import via custom field
- Add validation for item registration status
- Validate imported items are registered or submitted
- Use get_link_to_form() for user-friendly error messages
- Set update_stock flag for inventory updates

list_view: improve import fetching UX
- Add freeze screen with "Fetching Import Items..." message
- Improve user feedback during long-running API calls
- Keep empty callback and error handlers for clean structure

This workflow enables users to:
1. Fetch import items from ZRA API
2. Review fetched items in Registered Import Item list
3. Create Item, Supplier, and Purchase Invoice from import data
4. Maintain traceability between imports and created documents