### PR TITLE
feat(purchase): restrict Purchase Invoice creation to registered purc…

### DIFF
--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.js
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.js
@@ -64,7 +64,56 @@ frappe.ui.form.on(doctypeName, {
 				},
 				__("Smart Actions")
 			);
-
+frappe.db.get_value(
+				"Item",
+				{ item_code: frm.doc.item_name },
+				["custom_item_registered", "name"],
+				(response) => {
+					if (parseInt(response.custom_item_registered) === 1) {
+						frm.add_custom_button(
+							__("Create Purchase Invoice"),
+							function () {
+								frappe.call({
+									method: "ca_erpnext_zra.ca_erpnext_zra.apis.purchase_invoice.create_purchase_invoice_from_request",
+									args: {
+										request_data: {
+											name: frm.doc.name,
+											supplier_invoice_no: null,
+											supplier_invoice_date: null,
+											supplier_name: frm.doc.suppliers_name,
+											supplier_currency: frm.doc.invoice_foreign_currency,
+											supplier_nation: frm.doc.origin_nation_code,
+											supplier_branch_id: null,
+											exchange_rate: frm.doc.foreign_currency_exchange_rate,
+											currency: frm.doc.invoice_foreign_currency,
+											amount: frm.doc.invoice_foreign_currency_amount,
+											items: item,
+											task_code: frm.doc.task_code,
+											company_data: company_data,
+										},
+									},
+									callback: (response) => {
+										frappe.msgprint("Purchase Invoice has been created.");
+									},
+									error: (error) => {
+										// Error Handling is Defered to the Server
+									},
+									freeze: true,
+									freeze_message: __("Creating Purchase Invoice..."),
+								});
+							},
+							__("Smart Actions")
+						);
+					} else {
+						frm.set_intro(
+							__(
+								"Item not registered yet. Please register it to allow creation of a Purchase Invoice."
+							),
+							"red"
+						);
+					}
+				}
+			);
 			// // -------------------------------------------------------------
 			// // 🔹 3. CREATE PURCHASE INVOICE
 			// // -------------------------------------------------------------
@@ -122,31 +171,31 @@ frappe.ui.form.on(doctypeName, {
 			// -------------------------------------------------------------
 
 			// Show buttons only in Pending or empty state
-			if (!frm.doc.custom_purchase_status || frm.doc.custom_purchase_status === "Pending") {
-				frm.add_custom_button(
-					__("Approve Purchase"),
-					() => {
-						frappe.call({
-							method: "ca_erpnext_zra.ca_erpnext_zra.apis.purchase_api.approve_smart_purchase",
-							args: { name: frm.doc.name },
-							callback: () => frm.reload_doc(),
-						});
-					},
-					__("Smart Workflow")
-				);
+			// if (!frm.doc.custom_purchase_status || frm.doc.custom_purchase_status === "Pending") {
+			// 	frm.add_custom_button(
+			// 		__("Approve Purchase"),
+			// 		() => {
+			// 			frappe.call({
+			// 				method: "ca_erpnext_zra.ca_erpnext_zra.apis.purchase_api.approve_smart_purchase",
+			// 				args: { name: frm.doc.name },
+			// 				callback: () => frm.reload_doc(),
+			// 			});
+			// 		},
+			// 		__("Smart Workflow")
+			// 	);
 
-				frm.add_custom_button(
-					__("Reject Purchase"),
-					() => {
-						frappe.call({
-							method: "ca_erpnext_zra.ca_erpnext_zra.apis.purchase_api.reject_smart_purchase",
-							args: { name: frm.doc.name },
-							callback: () => frm.reload_doc(),
-						});
-					},
-					__("Smart Workflow")
-				);
-			}
+			// 	frm.add_custom_button(
+			// 		__("Reject Purchase"),
+			// 		() => {
+			// 			frappe.call({
+			// 				method: "ca_erpnext_zra.ca_erpnext_zra.apis.purchase_api.reject_smart_purchase",
+			// 				args: { name: frm.doc.name },
+			// 				callback: () => frm.reload_doc(),
+			// 			});
+			// 		},
+			// 		__("Smart Workflow")
+			// 	);
+			// }
 		}
 	},
 });

--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.json
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.json
@@ -176,8 +176,13 @@
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2025-11-18 12:02:46.898859",
+ "links": [
+  {
+   "link_doctype": "Purchase Invoice",
+   "link_fieldname": "custom_source_registered_purchase"
+  }
+ ],
+ "modified": "2025-11-24 08:55:00.751925",
  "modified_by": "Administrator",
  "module": "Ca Erpnext Zra",
  "name": "Crystallised ZRA Smart Purchases",

--- a/ca_erpnext_zra/ca_erpnext_zra/services/code_list_service.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/services/code_list_service.py
@@ -51,7 +51,7 @@ def handle_codes_response(response: dict | str, settings_name: str = None, **kwa
 		"04": {  # Taxation Types
 			"doctype": "Crystallised ZRA Smart Taxation Type",
 			"field_mapping": {"cd": "code", "cdNm": "code_name", "userDfnCd1": "user_defined_code_1"},
-			"unique_key": "c",
+			"unique_key": "code",
 			"parent_fields": {
 				"cdCls": "class_code",
 			},
@@ -106,9 +106,6 @@ def handle_codes_response(response: dict | str, settings_name: str = None, **kwa
 				"userDfnCd1": "user_defined_code_1",
 			},
 			"unique_key": "code",
-			"parent_fields": {
-				"cdCls": "class_code",
-			},
 		},
 		"11": {
 			"doctype": "Crystallised Smart Sale Status",
@@ -151,7 +148,7 @@ def handle_codes_response(response: dict | str, settings_name: str = None, **kwa
 			"parent_fields": {"cdCls": "class_code", "userDfnCd1": "user_defined_name_1"},
 		},
 		"17": {  # Packaging Units
-			"doctype": PACKAGING_UNIT_DOCTYPE_NAME,
+			"doctype": "Crystallised Smart Packaging Unit",
 			"field_mapping": {
 				"cd": "code",
 				"cdNm": "code_name",

--- a/ca_erpnext_zra/ca_erpnext_zra/services/item_service.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/services/item_service.py
@@ -41,7 +41,7 @@ def handle_registration_response(
 				return
 
 			# Find corresponding ERPNext Item
-			item_name = frappe.db.get_value("Item", {"item_code": item_code}, "name")
+			item_name = frappe.db.get_value("Item", {"custom_smart_item_code": item_code}, "name")
 			if not item_name:
 				frappe.log_error(f"[SMART] Item with code {item_code} not found", "Registration Handler")
 				return
@@ -159,14 +159,9 @@ def fetch_matching_items_on_success(response: dict, document_name: str, settings
 			frappe.logger().info(
 				f"[SMART] No existing ZRA item found for {item_doc.name}, creating new item."
 			)
-			existing_mapping = None  # explicitly set to None to trigger creation
-
-	# --- Build payload for registration/update ---
+			existing_mapping = None 
 	request_data = generate_vsdc_item_payload(item_doc.name, settings_name)
-
-	# Decide route key based on existing mapping
 	route_key = "updateItem" if existing_mapping else "saveItem"
-
 	frappe.enqueue(
 		process_request,
 		queue="default",

--- a/ca_erpnext_zra/ca_erpnext_zra/utils/payload_utils.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/utils/payload_utils.py
@@ -1494,22 +1494,42 @@ def build_sales_payload(sales_invoice_name, company_tpin, user="Admin"):
 
 	return payload
 
-
 def generate_custom_item_code_smart(doc: Document) -> str:
-	prefix_parts = [
-		doc.get("Crystallised Smart Country") or "",
-		doc.get("custom_smart_item_type") or "",
-		doc.get("custom_smart_packaging_unit") or "",
-		doc.get("custom_smart_quantity_unit") or "",
-		doc.get("custom_smart_item_classification_code") or "",
-	]
-	prefix = "".join(prefix_parts)
-	if doc.get("custom_smart_item_code"):
-		existing_suffix = doc.custom_smart_item_code[-7:]
-	else:
-		# Find last code under same classification to increment suffix
-		last_code = frappe.db.sql(
-			"""
+    """
+    Generate smart item code in fixed format:
+        CC T PP QQ CCCC SSSSSSS
+        
+        CC  = Country (2 chars)
+        T   = Item type (1 char)
+        PP  = Packaging unit (2 chars)
+        QQ  = Qty unit (2 chars)
+        CCCC = Classification code (4 chars, padded)
+        SSSSSSS = Running sequence (7 digits)
+    """
+
+    # --- Extract fields ---
+    country = (doc.get("custom_smart_country_of_origin_") or "").upper().strip()[:2]
+    item_type = (doc.get("custom_smart_item_type") or "").upper().strip()[:1]
+    pkg_unit = (doc.get("custom_smart_packaging_unit") or "").upper().strip()[:2]
+    qty_unit = (doc.get("custom_smart_quantity_unit") or "").upper().strip()[:2]
+    class_code = (doc.get("custom_smart_item_classification_code") or "").strip()
+
+    # --- Enforce padding ---
+    country = country.ljust(2)
+    item_type = item_type.ljust(1)
+    pkg_unit = pkg_unit.ljust(2)
+    qty_unit = qty_unit.ljust(2,)
+    class_code = class_code.zfill(4)  # always 4 digits
+
+    # --- Build prefix ---
+    prefix = f"{country}{item_type}{pkg_unit}{qty_unit}{class_code}"
+
+    # --- Determine suffix ---
+    if doc.get("custom_smart_item_code"):
+        suffix = doc.custom_smart_item_code[-7:]
+    else:
+        last = frappe.db.sql(
+            """
             SELECT custom_smart_item_code
             FROM `tabItem`
             WHERE custom_smart_item_classification_code = %s
@@ -1517,27 +1537,28 @@ def generate_custom_item_code_smart(doc: Document) -> str:
             ORDER BY CAST(RIGHT(custom_smart_item_code, 7) AS UNSIGNED) DESC
             LIMIT 1
             """,
-			(doc.custom_smart_item_classification_code,),
-		)
+            (doc.custom_smart_item_classification_code,),
+        )
 
-		last_code = last_code[0][0] if last_code else None
-		if last_code:
-			try:
-				last_suffix = int(last_code[-7:])
-				existing_suffix = str(last_suffix + 1).zfill(7)
-			except ValueError:
-				existing_suffix = "0000001"
-		else:
-			existing_suffix = "0000001"
+        if last:
+            last_code = last[0][0]
+            try:
+                suffix = str(int(last_code[-7:]) + 1).zfill(7)
+            except:
+                suffix = "0000001"
+        else:
+            suffix = "0000001"
 
-	# Final smart item code
-	new_code = f"{prefix}{existing_suffix}"
+    # --- Final smart code ---
+    new_code = f"{prefix}{suffix}"
 
-	# Save it back to the Item if needed
-	doc.db_set("custom_smart_item_code", new_code, update_modified=False)
-	frappe.logger().info(f"[SMART] Generated Smart Code for {doc.name}: {new_code}")
+    # Save
+    doc.db_set("custom_smart_item_code", new_code, update_modified=False)
 
-	return new_code
+    frappe.logger().info(f"[SMART] Generated Smart Code: {new_code}")
+
+    return new_code
+
 
 
 def build_import_item_payload(settings: dict):

--- a/ca_erpnext_zra/ca_erpnext_zra/utils/update_utils.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/utils/update_utils.py
@@ -14,7 +14,7 @@ def update_documents(
 	parentfield: str | None = None,
 	return_docs: bool = False,
 	ignore_if_duplicate: bool = False,
-) -> List[Document] | None:
+) -> list[Document] | None:
 	"""
 	Generic helper to insert or update documents from API responses.
 


### PR DESCRIPTION
This update introduces a validation layer that ensures only registered purchased items can be used when creating a Purchase Invoice. Items must originate from an approved Registerd Purchase before they can be invoiced.