### PR TITLE
feat: streamline registered import item update

### DIFF
--- a/ca_erpnext_zra/ca_erpnext_zra/apis/purchase_invoice.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/apis/purchase_invoice.py
@@ -1,10 +1,14 @@
 import json
+from datetime import datetime
 
 import frappe
 from frappe.utils import get_link_to_form
 
 from ..utils.create_supplier import get_or_create_supplier
 from .import_item import get_or_create_item
+from ..doctype.doctype_names_mapping import SETTINGS_DOCTYPE_NAME, REGISTERED_IMPORTED_ITEM_DOCTYPE_NAME
+from ..apis.api_processor import process_request
+from ..handlers.import_item_handler import import_item_update_on_success
 
 
 @frappe.whitelist()
@@ -43,7 +47,7 @@ def create_purchase_invoice_from_request(request_data: str) -> None:
 
 	purchase_invoice.set("items", [])
 
-	company_name = data["company_data"]["responseJSON"]["message"]["company_name"]
+	company_name = data["company_name"]
 	company_abbr = frappe.get_value("Company", company_name, "abbr")
 	expense_account = frappe.db.get_value(
 		"Account",
@@ -103,5 +107,157 @@ def validation_message(item_code):
 		frappe.throw(f"Register the item: {item_link}")
 
 
-def update_registered_import_item(request_data: list) -> None:
-	pass
+# @frappe.whitelist()
+# def update_registered_import_item(request_data: str) -> None:
+# 	data = json.loads(request_data)
+
+# 	grouped_items = {}
+
+# 	for item in data:
+# 		grouped_items.setdefault(
+# 			(item.get("task_code"), item.get("declaration_date"), item.get("settings_name")), []
+# 		).append(item)
+
+# 	if not grouped_items:
+# 		frappe.throw("No import items to update.")
+# 		return
+
+# 	for (task_code, declaration_date, settings_name), items in grouped_items.items():
+# 		tpin = frappe.db.get_value(SETTINGS_DOCTYPE_NAME, settings_name, "tpin")
+
+# 		if not tpin:
+# 			frappe.log_error(
+# 				f"TPIN not found in {SETTINGS_DOCTYPE_NAME} {settings_name}.", "Update Registered Import Item"
+# 			)
+# 			continue
+
+# 		item_payload = []
+
+# 		base_payload = {
+# 			"tpin": tpin,
+# 			"taskCd": task_code,
+# 			"bhfId": "000",
+# 			"dclDe": datetime.strptime(declaration_date, "%Y-%m-%d").strftime("%Y%m%d"),
+# 		}
+
+# 		for item in items:
+# 			try:
+# 				item_doc = frappe.db.get_value(
+# 					"Item",
+# 					{"item_code": item.get("item_name")},
+# 					[
+# 						"custom_smart_item_classification_code",
+# 						"custom_smart_item_code",
+# 						"custom_hs_code",
+# 					],
+# 					as_dict=True,
+# 				)
+# 				if not item_doc:
+# 					continue
+
+# 				item_payload.append(
+# 					{
+# 						"itemSeq": item.get("item_sequence"),
+# 						"hsCd": item.get("hs_code") or item_doc.custom_hs_code,
+# 						"itemClsCd": item_doc.custom_smart_item_classification_code,
+# 						"itemCd": item_doc.custom_smart_item_code,
+# 						"imptItemSttsCd": 3 if item.get("imported_item_status_code") == "Approved" else 4,
+# 						"remark": None,
+# 						"modrNm": item.get("modified_by"),
+# 						"modrId": item.get("modified_by").split("@")[0] or "Admin",
+# 					}
+# 				)
+# 			except Exception as e:
+# 				frappe.log_error("Error processing item for Import Update:", str(e))
+
+# 		if not item_payload:
+# 			continue
+
+# 		final_payload = {**base_payload, "importItemList": item_payload}
+
+# 		frappe.enqueue(
+# 			process_request,
+# 			queue="long",
+# 			timeout=60,
+# 			is_async=True,
+# 			job_name=f"update_imported_items_{task_code}",
+# 			request_data=final_payload,
+# 			route_key="updateImports",
+# 			request_method="POST",
+# 			handler_function=import_item_update_on_success,
+# 			doctype=REGISTERED_IMPORTED_ITEM_DOCTYPE_NAME,
+# 			settings_name=settings_name,
+# 		)
+
+
+@frappe.whitelist()
+def update_registered_import_item(request_data: str) -> None:
+	data = json.loads(request_data)
+
+	tpin = frappe.db.get_value(SETTINGS_DOCTYPE_NAME, data.get("settings_name"), "tpin")
+
+	if not tpin:
+		frappe.log_error(
+			f"TPIN not found in {SETTINGS_DOCTYPE_NAME} {data.get('settings_name')}.",
+			"Update Registered Import Item",
+		)
+		return
+
+	item_payload = []
+
+	base_payload = {
+		"tpin": tpin,
+		"taskCd": data.get("task_code"),
+		"bhfId": "000",
+		"dclDe": datetime.strptime(data.get("declaration_date"), "%Y-%m-%d").strftime("%Y%m%d"),
+	}
+
+	try:
+		item_doc = frappe.db.get_value(
+			"Item",
+			{"item_code": data.get("item_name")},
+			[
+				"custom_smart_item_classification_code",
+				"custom_smart_item_code",
+				"custom_hs_code",
+			],
+			as_dict=True,
+		)
+		if not item_doc:
+			return
+
+		item_payload.append(
+			{
+				"itemSeq": data.get("item_sequence"),
+				"hsCd": data.get("hs_code") or item_doc.custom_hs_code,
+				"itemClsCd": item_doc.custom_smart_item_classification_code,
+				"itemCd": item_doc.custom_smart_item_code,
+				"imptItemSttsCd": 3 if data.get("imported_item_status_code") == "Approved" else 4,
+				"remark": None,
+				"modrNm": data.get("modified_by"),
+				"modrId": data.get("modified_by").split("@")[0] or "Admin",
+			}
+		)
+	except Exception as e:
+		frappe.log_error("Error processing item for Import Update:", str(e))
+
+	if not item_payload:
+		return
+
+	final_payload = {**base_payload, "importItemList": item_payload}
+	frappe.log_error("document_name", data.get("name"))
+
+	frappe.enqueue(
+		process_request,
+		queue="long",
+		timeout=60,
+		is_async=True,
+		job_name=f"update_imported_items_{data.get('task_code')}",
+		request_data=final_payload,
+		route_key="updateImports",
+		# request_method="POST",
+		handler_function=import_item_update_on_success,
+		doctype=REGISTERED_IMPORTED_ITEM_DOCTYPE_NAME,
+		document_name=data.get("name"),
+		settings_name=data.get("settings_name"),
+	)

--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.js
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.js
@@ -5,10 +5,15 @@ const doctypeName = "Crystallised Smart Registered Import Item";
 
 frappe.ui.form.on(doctypeName, {
 	refresh: function (frm) {
-		const company_data = frappe.db.get_value(
+		let company_name;
+
+		frappe.db.get_value(
 			"Crystal ZRA Smart Invoice Settings",
-			frm.doc.settings,
-			"company_name"
+			{ name: frm.doc.settings },
+			["company_name"],
+			(response) => {
+				company_name = response.company_name;
+			}
 		);
 
 		const item = [
@@ -95,44 +100,163 @@ frappe.ui.form.on(doctypeName, {
 				["custom_item_registered", "name"],
 				(response) => {
 					if (parseInt(response.custom_item_registered) === 1) {
-						frm.add_custom_button(
-							__("Create Purchase Invoice"),
-							function () {
-								frappe.call({
-									method: "ca_erpnext_zra.ca_erpnext_zra.apis.purchase_invoice.create_purchase_invoice_from_request",
-									args: {
-										request_data: {
-											name: frm.doc.name,
-											supplier_invoice_no: null,
-											supplier_invoice_date: null,
-											supplier_name: frm.doc.suppliers_name,
-											supplier_currency: frm.doc.invoice_foreign_currency,
-											supplier_nation: frm.doc.origin_nation_code,
-											supplier_branch_id: null,
-											exchange_rate: frm.doc.foreign_currency_exchange_rate,
-											currency: frm.doc.invoice_foreign_currency,
-											amount: frm.doc.invoice_foreign_currency_amount,
-											items: item,
-											task_code: frm.doc.task_code,
-											company_data: company_data,
+						if (frm.doc.imported_item_status == "Approved") {
+							frm.add_custom_button(
+								__("Create Purchase Invoice"),
+								function () {
+									frappe.call({
+										method: "ca_erpnext_zra.ca_erpnext_zra.apis.purchase_invoice.create_purchase_invoice_from_request",
+										args: {
+											request_data: {
+												name: frm.doc.name,
+												supplier_invoice_no: null,
+												supplier_invoice_date: null,
+												supplier_name: frm.doc.suppliers_name,
+												supplier_currency:
+													frm.doc.invoice_foreign_currency,
+												supplier_nation: frm.doc.origin_nation_code,
+												supplier_branch_id: null,
+												exchange_rate:
+													frm.doc.foreign_currency_exchange_rate,
+												currency: frm.doc.invoice_foreign_currency,
+												amount: frm.doc.invoice_foreign_currency_amount,
+												items: item,
+												task_code: frm.doc.task_code,
+												company_name: company_name,
+											},
 										},
-									},
-									callback: (response) => {
-										frappe.msgprint("Purchase Invoice has been created.");
-									},
-									error: (error) => {
-										// Error Handling is Defered to the Server
-									},
-									freeze: true,
-									freeze_message: __("Creating Purchase Invoice..."),
-								});
-							},
-							__("Smart Actions")
-						);
+										callback: (response) => {
+											frappe.msgprint("Purchase Invoice has been created.");
+										},
+										error: (error) => {
+											// Error Handling is Defered to the Server
+										},
+										freeze: true,
+										freeze_message: __("Creating Purchase Invoice..."),
+									});
+								},
+								__("Smart Actions")
+							);
+						}
+
+						// frm.add_custom_button(
+						// 	"Update Import Item",
+						// 	function () {
+						// 		frappe.call({
+						// 			method: "ca_erpnext_zra.ca_erpnext_zra.apis.purchase_invoice.update_registered_import_item",
+						// 			args: {
+						// 				request_data: [
+						// 					{
+						// 						name: frm.doc.name,
+						// 						settings_name: frm.doc.settings,
+						// 						item_name: frm.doc.item_name,
+						// 						task_code: frm.doc.task_code,
+						// 						declaration_date: frm.doc.declaration_date,
+						// 						item_sequence: frm.doc.item_sequence,
+						// 						hs_code: frm.doc.hs_code,
+						// 						imported_item_status_code:
+						// 							frm.doc.imported_item_status_code,
+						// 						modified_by: frm.doc.modified_by,
+						// 					},
+						// 				],
+						// 			},
+						// 			callback: (response) => {
+						// 				frappe.msgprint(
+						// 					"Update of Import Item(s) has been queued."
+						// 				);
+						// 			},
+						// 			error: (error) => {
+						// 				// Error Handling is Defered to the Server
+						// 			},
+						// 			freeze: true,
+						// 			freeze_message: __("Updating Import Item..."),
+						// 		});
+						// 	},
+						// 	__("Smart Actions")
+						// );
+						if (frm.doc.imported_item_status !== "Approved") {
+							frm.add_custom_button(
+								"Update Import Item",
+								function () {
+									// Create dialog with two options
+									const dialog = new frappe.ui.Dialog({
+										title: __("Select Import Item Status"),
+										fields: [
+											{
+												fieldname: "imported_item_status_code",
+												label: __("Import Item Status Code"),
+												fieldtype: "Select",
+												options: [
+													{ value: "Approved", label: __("Approved") },
+													{ value: "Cancelled", label: __("Cancelled") },
+												],
+												default:
+													frm.doc.imported_item_status_code ||
+													"Approved",
+												reqd: 1,
+											},
+										],
+										primary_action_label: __("Update"),
+										primary_action: function (values) {
+											dialog.hide();
+
+											frappe.call({
+												method: "ca_erpnext_zra.ca_erpnext_zra.apis.purchase_invoice.update_registered_import_item",
+												args: {
+													// request_data: [
+													// 	{
+													// 		name: frm.doc.name,
+													// 		settings_name: frm.doc.settings,
+													// 		item_name: frm.doc.item_name,
+													// 		task_code: frm.doc.task_code,
+													// 		declaration_date: frm.doc.declaration_date,
+													// 		item_sequence: frm.doc.item_sequence,
+													// 		hs_code: frm.doc.hs_code,
+													// 		imported_item_status_code:
+													// 			values.imported_item_status_code,
+
+													// 		modified_by: frm.doc.modified_by,
+													// 		document_name: frm.doc.name,
+													// 	},
+													// ],
+													request_data: {
+														name: frm.doc.name,
+														settings_name: frm.doc.settings,
+														item_name: frm.doc.item_name,
+														task_code: frm.doc.task_code,
+														declaration_date: frm.doc.declaration_date,
+														item_sequence: frm.doc.item_sequence,
+														hs_code: frm.doc.hs_code,
+														imported_item_status_code:
+															values.imported_item_status_code,
+
+														modified_by: frm.doc.modified_by,
+														document_name: frm.doc.name,
+													},
+												},
+												callback: (response) => {
+													frappe.msgprint(
+														"Update of Import Item(s) has been queued."
+													);
+												},
+												error: (error) => {
+													// Error Handling is Deferred to the Server
+												},
+												freeze: true,
+												freeze_message: __("Updating Import Item..."),
+											});
+										},
+									});
+
+									dialog.show();
+								},
+								__("Smart Actions")
+							);
+						}
 					} else {
 						frm.set_intro(
 							__(
-								"Item not registered yet. Please register it to allow creation of a Purchase Invoice."
+								"Item not registered yet. Please register it to allow Update of Import Item."
 							),
 							"red"
 						);

--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.json
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.json
@@ -39,48 +39,56 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Item Name"
+   "label": "Item Name",
+   "read_only": 1
   },
   {
    "fieldname": "origin_nation_code",
    "fieldtype": "Link",
    "label": "Origin Nation Code",
-   "options": "Crystallised Smart Country"
+   "options": "Crystallised Smart Country",
+   "read_only": 1
   },
   {
    "fieldname": "declaration_date",
    "fieldtype": "Date",
-   "label": "Declaration Date"
+   "label": "Declaration Date",
+   "read_only": 1
   },
   {
    "fieldname": "item_sequence",
    "fieldtype": "Int",
-   "label": "Item Sequence"
+   "label": "Item Sequence",
+   "read_only": 1
   },
   {
    "fieldname": "package",
    "fieldtype": "Data",
-   "label": "Package"
+   "label": "Package",
+   "read_only": 1
   },
   {
    "fieldname": "suppliers_name",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Supplier's Name"
+   "label": "Supplier's Name",
+   "read_only": 1
   },
   {
    "fieldname": "invoice_foreign_currency",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Invoice Foreign Currency",
-   "options": "Currency"
+   "options": "Currency",
+   "read_only": 1
   },
   {
    "fieldname": "invoice_foreign_currency_amount",
    "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Invoice Foreign Currency Amount",
-   "options": "invoice_foreign_currency"
+   "options": "invoice_foreign_currency",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_okps",
@@ -89,40 +97,47 @@
   {
    "fieldname": "task_code",
    "fieldtype": "Data",
-   "label": "Task Code"
+   "label": "Task Code",
+   "read_only": 1
   },
   {
    "fieldname": "export_nation_code",
    "fieldtype": "Link",
    "label": "Export Nation Code",
-   "options": "Crystallised Smart Country"
+   "options": "Crystallised Smart Country",
+   "read_only": 1
   },
   {
    "fieldname": "declaration_number",
    "fieldtype": "Data",
-   "label": "Declaration Number"
+   "label": "Declaration Number",
+   "read_only": 1
   },
   {
    "fieldname": "hs_code",
    "fieldtype": "Data",
-   "label": "HS Code"
+   "label": "HS Code",
+   "read_only": 1
   },
   {
    "fieldname": "packaging_unit_code",
    "fieldtype": "Link",
    "label": "Packaging Unit Code",
-   "options": "Crystallised Smart Packaging Unit"
+   "options": "Crystallised Smart Packaging Unit",
+   "read_only": 1
   },
   {
    "fieldname": "quantity_unit_code",
    "fieldtype": "Link",
    "label": "Quantity Unit Code",
-   "options": "Crystallised Smart Unit Of Quantity"
+   "options": "Crystallised Smart Unit Of Quantity",
+   "read_only": 1
   },
   {
    "fieldname": "agent_name",
    "fieldtype": "Data",
-   "label": "Agent Name"
+   "label": "Agent Name",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_mytx",
@@ -132,7 +147,8 @@
    "fieldname": "settings",
    "fieldtype": "Link",
    "label": "Settings",
-   "options": "Crystal ZRA Smart Invoice Settings"
+   "options": "Crystal ZRA Smart Invoice Settings",
+   "read_only": 1
   },
   {
    "fieldname": "imported_item_status",
@@ -140,42 +156,50 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Imported Item Status",
-   "options": "Crystallised Smart Import Item Status"
+   "options": "Crystallised Smart Import Item Status",
+   "read_only": 1
   },
   {
    "fieldname": "imported_item_status_code",
    "fieldtype": "Data",
-   "label": "Imported Item Status Code"
+   "label": "Imported Item Status Code",
+   "read_only": 1
   },
   {
    "fieldname": "quantity",
    "fieldtype": "Float",
-   "label": "Quantity"
+   "label": "Quantity",
+   "read_only": 1
   },
   {
    "fieldname": "net_weight",
    "fieldtype": "Float",
-   "label": "Net Weight"
+   "label": "Net Weight",
+   "read_only": 1
   },
   {
    "fieldname": "gross_weight",
    "fieldtype": "Float",
-   "label": "Gross Weight"
+   "label": "Gross Weight",
+   "read_only": 1
   },
   {
    "fieldname": "declaration_reference_number",
    "fieldtype": "Data",
-   "label": "Declaration Reference Number"
+   "label": "Declaration Reference Number",
+   "read_only": 1
   },
   {
    "fieldname": "foreign_currency_exchange_rate",
    "fieldtype": "Float",
-   "label": "Foreign Currency Exchange Rate"
+   "label": "Foreign Currency Exchange Rate",
+   "read_only": 1
   },
   {
    "fieldname": "item_identifier",
    "fieldtype": "Data",
    "label": "Item Identifier",
+   "read_only": 1,
    "unique": 1
   }
  ],
@@ -192,7 +216,7 @@
    "link_fieldname": "custom_import_source_registered_purchase"
   }
  ],
- "modified": "2025-11-21 12:33:00.405375",
+ "modified": "2025-11-25 09:58:30.750796",
  "modified_by": "Administrator",
  "module": "Ca Erpnext Zra",
  "name": "Crystallised Smart Registered Import Item",

--- a/ca_erpnext_zra/ca_erpnext_zra/handlers/import_item_handler.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/handlers/import_item_handler.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 
 import frappe
@@ -86,6 +87,20 @@ def imported_items_select_on_success(response: dict, settings_name: str, **kwarg
 
 	frappe.msgprint(
 		"Imported Items fetched successfully. Go to <b>Crystallised Smart Registered Import Item</b> Doctype for more information."
+	)
+
+
+def import_item_update_on_success(response: dict, document_name: str, **kwargs) -> None:
+	frappe.log_error("Import Item Update Response", document_name)
+	import_item_list = kwargs.get("payload", {}).get("importItemList", [])
+
+	status_code = import_item_list[0].get("imptItemSttsCd")
+	status_code_name = frappe.db.get_value(IMPORTED_ITEMS_STATUS_DOCTYPE_NAME, {"code": status_code}, "name")
+	frappe.log_error("KWARGS", f"{status_code} - {status_code_name}")
+	frappe.db.set_value(
+		REGISTERED_IMPORTED_ITEM_DOCTYPE_NAME,
+		document_name,
+		{"imported_item_status_code": status_code, "imported_item_status": status_code_name},
 	)
 
 

--- a/ca_erpnext_zra/fixtures/crystal_smart_invoice_routes.json
+++ b/ca_erpnext_zra/fixtures/crystal_smart_invoice_routes.json
@@ -2,7 +2,7 @@
  {
   "docstatus": 0,
   "doctype": "Crystal Smart Invoice Routes",
-  "modified": "2025-11-18 17:46:46.452864",
+  "modified": "2025-11-24 16:39:29.536520",
   "name": "saleq619bb",
   "route_table": [
    {
@@ -139,6 +139,15 @@
     "parenttype": "Crystal Smart Invoice Routes",
     "url_path": "/api/v1/ImportItemsInfo/selectImportItems",
     "url_path_function": "selectImports"
+   },
+   {
+    "description": null,
+    "last_request_date": null,
+    "parent": "saleq619bb",
+    "parentfield": "route_table",
+    "parenttype": "Crystal Smart Invoice Routes",
+    "url_path": "/api/v1/ImportItemsInfo/updateImportItems",
+    "url_path_function": "updateImports"
    }
   ],
   "vendor": "Crystal VSDC"


### PR DESCRIPTION
- pull company context into purchase invoice creation and add a single-item import update queue that enriches payloads before hitting the Smart API
- show purchase invoice creation button when an import item is approved
- add a dialog-driven import status update action on the Registered Import Item form
- add successful callback handler for import item update
- lock down imported fields and persist Smart API status callbacks back onto the DocType