### PR TITLE
feat: enhance purchase invoice creation with user input dialog and import defaults

### DIFF
--- a/ca_erpnext_zra/ca_erpnext_zra/apis/purchase_invoice.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/apis/purchase_invoice.py
@@ -39,6 +39,7 @@ def create_purchase_invoice_from_request(request_data: str) -> None:
 	purchase_invoice.bill_date = data["supplier_invoice_date"]
 	purchase_invoice.custom_import_source_registered_purchase = data["name"]
 	purchase_invoice.custom_smart_purchase_id = data["name"]
+	purchase_invoice.credit_to = data.get("creditors_account")
 	if "currency" in data:
 		# The "currency" key is only available when creating from Imported Item
 		purchase_invoice.currency = data["currency"]
@@ -105,89 +106,6 @@ def validation_message(item_code):
 	elif not item_doc.custom_referenced_imported_item and item_doc.custom_item_registered == 0:
 		item_link = get_link_to_form("Item", item_doc.name)
 		frappe.throw(f"Register the item: {item_link}")
-
-
-# @frappe.whitelist()
-# def update_registered_import_item(request_data: str) -> None:
-# 	data = json.loads(request_data)
-
-# 	grouped_items = {}
-
-# 	for item in data:
-# 		grouped_items.setdefault(
-# 			(item.get("task_code"), item.get("declaration_date"), item.get("settings_name")), []
-# 		).append(item)
-
-# 	if not grouped_items:
-# 		frappe.throw("No import items to update.")
-# 		return
-
-# 	for (task_code, declaration_date, settings_name), items in grouped_items.items():
-# 		tpin = frappe.db.get_value(SETTINGS_DOCTYPE_NAME, settings_name, "tpin")
-
-# 		if not tpin:
-# 			frappe.log_error(
-# 				f"TPIN not found in {SETTINGS_DOCTYPE_NAME} {settings_name}.", "Update Registered Import Item"
-# 			)
-# 			continue
-
-# 		item_payload = []
-
-# 		base_payload = {
-# 			"tpin": tpin,
-# 			"taskCd": task_code,
-# 			"bhfId": "000",
-# 			"dclDe": datetime.strptime(declaration_date, "%Y-%m-%d").strftime("%Y%m%d"),
-# 		}
-
-# 		for item in items:
-# 			try:
-# 				item_doc = frappe.db.get_value(
-# 					"Item",
-# 					{"item_code": item.get("item_name")},
-# 					[
-# 						"custom_smart_item_classification_code",
-# 						"custom_smart_item_code",
-# 						"custom_hs_code",
-# 					],
-# 					as_dict=True,
-# 				)
-# 				if not item_doc:
-# 					continue
-
-# 				item_payload.append(
-# 					{
-# 						"itemSeq": item.get("item_sequence"),
-# 						"hsCd": item.get("hs_code") or item_doc.custom_hs_code,
-# 						"itemClsCd": item_doc.custom_smart_item_classification_code,
-# 						"itemCd": item_doc.custom_smart_item_code,
-# 						"imptItemSttsCd": 3 if item.get("imported_item_status_code") == "Approved" else 4,
-# 						"remark": None,
-# 						"modrNm": item.get("modified_by"),
-# 						"modrId": item.get("modified_by").split("@")[0] or "Admin",
-# 					}
-# 				)
-# 			except Exception as e:
-# 				frappe.log_error("Error processing item for Import Update:", str(e))
-
-# 		if not item_payload:
-# 			continue
-
-# 		final_payload = {**base_payload, "importItemList": item_payload}
-
-# 		frappe.enqueue(
-# 			process_request,
-# 			queue="long",
-# 			timeout=60,
-# 			is_async=True,
-# 			job_name=f"update_imported_items_{task_code}",
-# 			request_data=final_payload,
-# 			route_key="updateImports",
-# 			request_method="POST",
-# 			handler_function=import_item_update_on_success,
-# 			doctype=REGISTERED_IMPORTED_ITEM_DOCTYPE_NAME,
-# 			settings_name=settings_name,
-# 		)
 
 
 @frappe.whitelist()

--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystal_zra_smart_invoice_settings/crystal_zra_smart_invoice_settings.js
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystal_zra_smart_invoice_settings/crystal_zra_smart_invoice_settings.js
@@ -144,5 +144,21 @@ frappe.ui.form.on("Crystal ZRA Smart Invoice Settings", {
 			},
 			__("Smart Actions")
 		);
+
+		frm.trigger("setWarehouseQuery");
+	},
+
+	company_name: function (frm) {
+		frm.trigger("setWarehouseQuery");
+	},
+
+	setWarehouseQuery(frm) {
+		frm.set_query("default_import_warehouse", function () {
+			return {
+				filters: {
+					company: frm.doc.company_name,
+				},
+			};
+		});
 	},
 });

--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystal_zra_smart_invoice_settings/crystal_zra_smart_invoice_settings.json
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystal_zra_smart_invoice_settings/crystal_zra_smart_invoice_settings.json
@@ -42,6 +42,8 @@
   "mode_of_payment",
   "default_taxation_type_code",
   "default_tax_rate",
+  "imports_defaults_section",
+  "default_import_warehouse",
   "auth_details_tab",
   "username",
   "password",
@@ -291,12 +293,23 @@
    "fieldtype": "Table",
    "label": "Organisation Mapping",
    "options": "Smart Settings Organisation Mapping"
+  },
+  {
+   "fieldname": "imports_defaults_section",
+   "fieldtype": "Section Break",
+   "label": "Imports Defaults"
+  },
+  {
+   "fieldname": "default_import_warehouse",
+   "fieldtype": "Link",
+   "label": "Default Import Warehouse",
+   "options": "Warehouse"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-11-27 13:55:10.090429",
+ "modified": "2025-12-04 12:58:42.487982",
  "modified_by": "Administrator",
  "module": "Ca Erpnext Zra",
  "name": "Crystal ZRA Smart Invoice Settings",

--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.js
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.js
@@ -5,14 +5,14 @@ const doctypeName = "Crystallised Smart Registered Import Item";
 
 frappe.ui.form.on(doctypeName, {
 	refresh: function (frm) {
-		let company_name;
+		let warehouse;
 
 		frappe.db.get_value(
 			"Crystal ZRA Smart Invoice Settings",
 			{ name: frm.doc.settings },
-			["company_name"],
+			["default_import_warehouse"],
 			(response) => {
-				company_name = response.company_name;
+				warehouse = response.default_import_warehouse;
 			}
 		);
 
@@ -104,79 +104,131 @@ frappe.ui.form.on(doctypeName, {
 							frm.doc.imported_item_status == "Approved" ||
 							frm.doc.imported_item_status == 3
 						) {
+							// frm.add_custom_button(
+							// 	__("Create Purchase Invoice"),
+							// 	function () {
+
+							// 		frappe.call({
+							// 			method: "ca_erpnext_zra.ca_erpnext_zra.apis.purchase_invoice.create_purchase_invoice_from_request",
+							// 			args: {
+							// 				request_data: {
+							// 					name: frm.doc.name,
+							// 					supplier_invoice_no: null,
+							// 					supplier_invoice_date: null,
+							// 					supplier_name: frm.doc.suppliers_name,
+							// 					supplier_currency:
+							// 						frm.doc.invoice_foreign_currency,
+							// 					supplier_nation: frm.doc.origin_nation_code,
+							// 					supplier_branch_id: null,
+							// 					exchange_rate:
+							// 						frm.doc.foreign_currency_exchange_rate,
+							// 					currency: frm.doc.invoice_foreign_currency,
+							// 					amount: frm.doc.invoice_foreign_currency_amount,
+							// 					items: item,
+							// 					task_code: frm.doc.task_code,
+							// 					company_name: company_name,
+							// 				},
+							// 			},
+							// 			callback: (response) => {
+							// 				frappe.msgprint("Purchase Invoice has been created.");
+							// 			},
+							// 			error: (error) => {
+							// 				// Error Handling is Defered to the Server
+							// 			},
+							// 			freeze: true,
+							// 			freeze_message: __("Creating Purchase Invoice..."),
+							// 		});
+							// 	},
+							// 	__("Smart Actions")
+							// );
 							frm.add_custom_button(
 								__("Create Purchase Invoice"),
 								function () {
-									frappe.call({
-										method: "ca_erpnext_zra.ca_erpnext_zra.apis.purchase_invoice.create_purchase_invoice_from_request",
-										args: {
-											request_data: {
-												name: frm.doc.name,
-												supplier_invoice_no: null,
-												supplier_invoice_date: null,
-												supplier_name: frm.doc.suppliers_name,
-												supplier_currency:
-													frm.doc.invoice_foreign_currency,
-												supplier_nation: frm.doc.origin_nation_code,
-												supplier_branch_id: null,
-												exchange_rate:
-													frm.doc.foreign_currency_exchange_rate,
-												currency: frm.doc.invoice_foreign_currency,
-												amount: frm.doc.invoice_foreign_currency_amount,
-												items: item,
-												task_code: frm.doc.task_code,
-												company_name: company_name,
+									const dialog = new frappe.ui.Dialog({
+										title: __("Purchase Invoice Settings"),
+										fields: [
+											{
+												fieldname: "creditors_account",
+												label: __("Creditors Account"),
+												fieldtype: "Link",
+												options: "Account",
+												reqd: 1,
+												filters: {
+													account_type: "Payable",
+													company: frm.doc.company,
+													account_currency:
+														frm.doc.invoice_foreign_currency,
+												},
 											},
+											{
+												fieldname: "default_warehouse",
+												label: __("Default Warehouse"),
+												fieldtype: "Link",
+												options: "Warehouse",
+												reqd: 1,
+												default: warehouse,
+												filters: {
+													company: frm.doc.company,
+												},
+											},
+										],
+										primary_action_label: __("Create"),
+										primary_action(values) {
+											dialog.hide();
+
+											frappe.call({
+												method: "ca_erpnext_zra.ca_erpnext_zra.apis.purchase_invoice.create_purchase_invoice_from_request",
+												args: {
+													request_data: {
+														name: frm.doc.name,
+														supplier_invoice_no: null,
+														supplier_invoice_date: null,
+														supplier_name: frm.doc.suppliers_name,
+														supplier_currency:
+															frm.doc.invoice_foreign_currency,
+														supplier_nation:
+															frm.doc.origin_nation_code,
+														supplier_branch_id: null,
+														exchange_rate:
+															frm.doc.foreign_currency_exchange_rate,
+														currency: frm.doc.invoice_foreign_currency,
+														amount: frm.doc
+															.invoice_foreign_currency_amount,
+														items: item,
+														task_code: frm.doc.task_code,
+														company_name: frm.doc.company,
+														creditors_account:
+															values.creditors_account,
+														default_warehouse:
+															values.default_warehouse,
+													},
+												},
+												callback: (response) => {
+													frappe.msgprint(
+														__("Purchase Invoice has been created.")
+													);
+												},
+												error: (error) => {
+													frappe.msgprint({
+														title: __("Error"),
+														indicator: "red",
+														message: __(
+															"Failed to create Purchase Invoice."
+														),
+													});
+												},
+												freeze: true,
+												freeze_message: __("Creating Purchase Invoice..."),
+											});
 										},
-										callback: (response) => {
-											frappe.msgprint("Purchase Invoice has been created.");
-										},
-										error: (error) => {
-											// Error Handling is Defered to the Server
-										},
-										freeze: true,
-										freeze_message: __("Creating Purchase Invoice..."),
 									});
+
+									dialog.show();
 								},
 								__("Smart Actions")
 							);
 						}
 
-						// frm.add_custom_button(
-						// 	"Update Import Item",
-						// 	function () {
-						// 		frappe.call({
-						// 			method: "ca_erpnext_zra.ca_erpnext_zra.apis.purchase_invoice.update_registered_import_item",
-						// 			args: {
-						// 				request_data: [
-						// 					{
-						// 						name: frm.doc.name,
-						// 						settings_name: frm.doc.settings,
-						// 						item_name: frm.doc.item_name,
-						// 						task_code: frm.doc.task_code,
-						// 						declaration_date: frm.doc.declaration_date,
-						// 						item_sequence: frm.doc.item_sequence,
-						// 						hs_code: frm.doc.hs_code,
-						// 						imported_item_status_code:
-						// 							frm.doc.imported_item_status_code,
-						// 						modified_by: frm.doc.modified_by,
-						// 					},
-						// 				],
-						// 			},
-						// 			callback: (response) => {
-						// 				frappe.msgprint(
-						// 					"Update of Import Item(s) has been queued."
-						// 				);
-						// 			},
-						// 			error: (error) => {
-						// 				// Error Handling is Defered to the Server
-						// 			},
-						// 			freeze: true,
-						// 			freeze_message: __("Updating Import Item..."),
-						// 		});
-						// 	},
-						// 	__("Smart Actions")
-						// );
 						if (frm.doc.imported_item_status !== "Approved") {
 							frm.add_custom_button(
 								"Update Import Item",
@@ -206,22 +258,6 @@ frappe.ui.form.on(doctypeName, {
 											frappe.call({
 												method: "ca_erpnext_zra.ca_erpnext_zra.apis.purchase_invoice.update_registered_import_item",
 												args: {
-													// request_data: [
-													// 	{
-													// 		name: frm.doc.name,
-													// 		settings_name: frm.doc.settings,
-													// 		item_name: frm.doc.item_name,
-													// 		task_code: frm.doc.task_code,
-													// 		declaration_date: frm.doc.declaration_date,
-													// 		item_sequence: frm.doc.item_sequence,
-													// 		hs_code: frm.doc.hs_code,
-													// 		imported_item_status_code:
-													// 			values.imported_item_status_code,
-
-													// 		modified_by: frm.doc.modified_by,
-													// 		document_name: frm.doc.name,
-													// 	},
-													// ],
 													request_data: {
 														name: frm.doc.name,
 														settings_name: frm.doc.settings,

--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.json
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.json
@@ -26,6 +26,7 @@
   "invoice_foreign_currency_amount",
   "column_break_mytx",
   "settings",
+  "company",
   "imported_item_status",
   "imported_item_status_code",
   "quantity_unit_code",
@@ -201,6 +202,13 @@
    "label": "Item Identifier",
    "read_only": 1,
    "unique": 1
+  },
+  {
+   "fetch_from": "settings.company_name",
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company"
   }
  ],
  "grid_page_length": 50,
@@ -216,7 +224,7 @@
    "link_fieldname": "custom_import_source_registered_purchase"
   }
  ],
- "modified": "2025-11-25 09:58:30.750796",
+ "modified": "2025-12-04 16:44:28.086849",
  "modified_by": "Administrator",
  "module": "Ca Erpnext Zra",
  "name": "Crystallised Smart Registered Import Item",

--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item_list.js
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item_list.js
@@ -5,17 +5,45 @@ const doctypeName = "Crystallised Smart Registered Import Item";
 
 frappe.listview_settings[doctypeName] = {
 	onload: function (listview) {
-		const company = frappe.boot.sysdefaults.company;
+		const default_company = frappe.boot.sysdefaults.company;
 
 		listview.page.add_inner_button(__("Get Import Items"), function () {
-			frappe.call({
-				method: "ca_erpnext_zra.ca_erpnext_zra.apis.import_item.select_import_items_all_branches",
-				args: { company_name: company },
-				callback: function (r) {},
-				error: function (err) {},
-				freeze: true,
-				freeze_message: __("Fetching Import Items..."),
+			const dialog = new frappe.ui.Dialog({
+				title: __("Select Company"),
+				fields: [
+					{
+						fieldname: "company",
+						label: __("Company"),
+						fieldtype: "Link",
+						options: "Company",
+						reqd: 1,
+						default: default_company,
+					},
+				],
+				primary_action_label: __("Fetch"),
+				primary_action(values) {
+					dialog.hide();
+
+					frappe.call({
+						method: "ca_erpnext_zra.ca_erpnext_zra.apis.import_item.select_import_items_all_branches",
+						args: {
+							company_name: values.company,
+						},
+						callback: function (r) {},
+						error: function (err) {
+							frappe.msgprint({
+								title: __("Error"),
+								indicator: "red",
+								message: __("Failed to fetch Import Items."),
+							});
+						},
+						freeze: true,
+						freeze_message: __("Fetching Import Items..."),
+					});
+				},
 			});
+
+			dialog.show();
 		});
 	},
 };


### PR DESCRIPTION


Add interactive dialog for purchase invoice creation and improve import item management with configurable defaults and better company handling.

Purchase Invoice Creation Enhancements:
- Add interactive dialog for creating purchase invoices from import items with required fields for creditors account and default warehouse
- Set credit_to field on purchase invoice from user-selected creditors account
- Pass default_warehouse from dialog to purchase invoice creation process
- Improve error handling with user-friendly error messages
- Replace direct invoice creation with dialog-based workflow for better UX

Settings and Configuration:
- Add "Imports Defaults" section to Crystal ZRA Smart Invoice Settings
- Add default_import_warehouse field to settings doctype
- Implement warehouse query filtering by company in settings form
- Add setWarehouseQuery function to filter warehouses by selected company

Import Item Doctype Improvements:
- Add company field to Crystallised Smart Registered Import Item doctype
- Fetch company from settings.company_name using fetch_from relationship
- Update references to use frm.doc.company instead of fetching separately
- Change warehouse fetch logic to use default_import_warehouse from settings

List View Enhancements:
- Add company selection dialog to "Get Import Items" action in list view
- Replace hardcoded sysdefaults.company with user-selectable company
- Improve error handling in import items fetch operation

Code Cleanup:
- Remove commented-out code blocks for cleaner codebase
- Consolidate company reference handling throughout the codebase
- Improve code maintainability and readability

BREAKING CHANGE: Purchase Invoice creation now requires user input through dialog