### PR TITLE
feat: add branch-specific import functionality and branch tracking

### DIFF
--- a/ca_erpnext_zra/ca_erpnext_zra/apis/import_item.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/apis/import_item.py
@@ -13,24 +13,24 @@ from ..utils.routes_utils import get_route_path
 
 
 @frappe.whitelist()
-def select_import_items_all_branches() -> None:
-	all_credentials = frappe.get_all(
-		SETTINGS_DOCTYPE_NAME, ["name", "company_name", "tpin"], {"is_active": 1}
+def select_import_items(company_name: str, branch_name: str) -> None:
+	credential = frappe.db.get_value(
+		SETTINGS_DOCTYPE_NAME, {"company_name": company_name}, ["name", "company_name", "tpin"], as_dict=True
 	)
 
-	if len(all_credentials) < 1:
+	if not credential:
 		frappe.throw(f"No Active {SETTINGS_DOCTYPE_NAME} found.")
+
+	branch_code = frappe.db.get_value("Branch", {"name": branch_name}, "custom_branch_code")
 
 	route_key = "selectImports"
 
-	for cred in all_credentials:
-		request_data = build_import_item_payload(cred)
-
-		_, last_req_date = get_route_path(route_key, "Crystal VSDC")
-		request_date = add_to_date(datetime.now(), years=-1).strftime("%Y%m%d%H%M%S")
-		last_req_date = last_req_date.strftime("%Y%m%d%H%M%S") if last_req_date else request_date
-		request_data.update({"lastReqDt": last_req_date})
-		perform_import_item(request_data, cred.name, route_key)
+	request_data = build_import_item_payload(credential)
+	_, last_req_date = get_route_path(route_key, "Crystal VSDC")
+	request_date = add_to_date(datetime.now(), years=-1).strftime("%Y%m%d%H%M%S")
+	last_req_date = last_req_date.strftime("%Y%m%d%H%M%S") if last_req_date else request_date
+	request_data.update({"lastReqDt": last_req_date, "bhfId": branch_code})
+	perform_import_item(request_data, credential.name, route_key)
 
 
 def perform_import_item(request_data: str, settings_name: str, route_key: str):
@@ -41,11 +41,12 @@ def perform_import_item(request_data: str, settings_name: str, route_key: str):
 		request_method="POST",
 		doctype="Item",
 		settings_name=settings_name,
+		bhfid=request_data.get("bhfId"),
 	)
 
 
 @frappe.whitelist()
-def create_items_from_fetched_registered_imports(request_data: str) -> None:
+def create_item_from_fetched_registered_import(request_data: str) -> None:
 	data = json.loads(request_data)
 	if data["items"]:
 		items = data["items"]

--- a/ca_erpnext_zra/ca_erpnext_zra/apis/purchase_invoice.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/apis/purchase_invoice.py
@@ -129,7 +129,7 @@ def update_registered_import_item(request_data: str) -> None:
 	base_payload = {
 		"tpin": tpin,
 		"taskCd": data.get("task_code"),
-		"bhfId": "000",
+		"bhfId": data.get("branch_code"),
 		"dclDe": datetime.strptime(data.get("declaration_date"), "%Y-%m-%d").strftime("%Y%m%d"),
 	}
 

--- a/ca_erpnext_zra/ca_erpnext_zra/apis/purchase_invoice.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/apis/purchase_invoice.py
@@ -30,10 +30,13 @@ def create_purchase_invoice_from_request(request_data: str) -> None:
 		if received_item["item_name"] not in all_existing_items:
 			_ = get_or_create_item(received_item)
 
+	branch = frappe.db.get_value("Branch", {"custom_branch_code": data.get("branch_code")}, "name")
+
 	# Create the Purchase Invoice
 	purchase_invoice = frappe.new_doc("Purchase Invoice")
 	purchase_invoice.supplier = supplier or data["supplier_name"]
 	purchase_invoice.company = data["company_name"]
+	purchase_invoice.branch = branch
 	purchase_invoice.update_stock = 1
 	purchase_invoice.bill_no = data["supplier_invoice_no"]
 	purchase_invoice.bill_date = data["supplier_invoice_date"]

--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.js
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.js
@@ -42,7 +42,7 @@ frappe.ui.form.on(doctypeName, {
 				__("Create Item"),
 				function () {
 					frappe.call({
-						method: "ca_erpnext_zra.ca_erpnext_zra.apis.import_item.create_items_from_fetched_registered_imports",
+						method: "ca_erpnext_zra.ca_erpnext_zra.apis.import_item.create_item_from_fetched_registered_import",
 						args: {
 							request_data: {
 								items: item,
@@ -201,6 +201,7 @@ frappe.ui.form.on(doctypeName, {
 															values.creditors_account,
 														default_warehouse:
 															values.default_warehouse,
+														branch_code: frm.doc.branch_code,
 													},
 												},
 												callback: (response) => {

--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.js
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.js
@@ -264,6 +264,7 @@ frappe.ui.form.on(doctypeName, {
 														settings_name: frm.doc.settings,
 														item_name: frm.doc.item_name,
 														task_code: frm.doc.task_code,
+														branch_code: frm.doc.branch_code,
 														declaration_date: frm.doc.declaration_date,
 														item_sequence: frm.doc.item_sequence,
 														hs_code: frm.doc.hs_code,

--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.json
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item.json
@@ -27,6 +27,7 @@
   "column_break_mytx",
   "settings",
   "company",
+  "branch_code",
   "imported_item_status",
   "imported_item_status_code",
   "quantity_unit_code",
@@ -209,6 +210,12 @@
    "fieldtype": "Link",
    "label": "Company",
    "options": "Company"
+  },
+  {
+   "fieldname": "branch_code",
+   "fieldtype": "Data",
+   "label": "Branch Code",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -224,7 +231,7 @@
    "link_fieldname": "custom_import_source_registered_purchase"
   }
  ],
- "modified": "2025-12-04 16:44:28.086849",
+ "modified": "2025-12-08 17:11:35.880424",
  "modified_by": "Administrator",
  "module": "Ca Erpnext Zra",
  "name": "Crystallised Smart Registered Import Item",

--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item_list.js
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_smart_registered_import_item/crystallised_smart_registered_import_item_list.js
@@ -19,15 +19,23 @@ frappe.listview_settings[doctypeName] = {
 						reqd: 1,
 						default: default_company,
 					},
+					{
+						fieldname: "branch",
+						label: __("Branch"),
+						fieldtype: "Link",
+						options: "Branch",
+						reqd: 1,
+					},
 				],
 				primary_action_label: __("Fetch"),
 				primary_action(values) {
 					dialog.hide();
 
 					frappe.call({
-						method: "ca_erpnext_zra.ca_erpnext_zra.apis.import_item.select_import_items_all_branches",
+						method: "ca_erpnext_zra.ca_erpnext_zra.apis.import_item.select_import_items",
 						args: {
 							company_name: values.company,
+							branch_name: values.branch,
 						},
 						callback: function (r) {},
 						error: function (err) {

--- a/ca_erpnext_zra/ca_erpnext_zra/handlers/import_item_handler.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/handlers/import_item_handler.py
@@ -69,6 +69,7 @@ def imported_items_select_on_success(response: dict, settings_name: str, **kwarg
 				"invoice_foreign_currency": item.get("invcFcurCd"),
 				"foreign_currency_exchange_rate": item.get("invcFcurExcrt"),
 				"settings": settings_name,
+				"branch_code": kwargs.get("bhfId"),
 			}
 
 			item_doc = frappe.get_doc({"doctype": REGISTERED_IMPORTED_ITEM_DOCTYPE_NAME, **response_data})

--- a/ca_erpnext_zra/ca_erpnext_zra/utils/payload_utils.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/utils/payload_utils.py
@@ -124,7 +124,7 @@ def build_debit_note_payload(docname: str, settings_name: str | None = None) -> 
 	doc = frappe.get_doc("Sales Invoice", docname)
 
 	tpin = ""
-	branch_code = "000" 
+	branch_code = "000"
 	try:
 		if hasattr(doc, "branch") and doc.branch:
 			branch_doc = frappe.get_doc("Branch", doc.branch)
@@ -132,7 +132,6 @@ def build_debit_note_payload(docname: str, settings_name: str | None = None) -> 
 	except Exception as e:
 		frappe.log_error(f"Failed to fetch branch code: {e}", "Branch Code Error")
 
-	
 	if not settings_name:
 		settings_record = frappe.get_all("Crystal ZRA Smart Invoice Settings", fields=["name"], limit=1)
 		if settings_record:
@@ -141,8 +140,6 @@ def build_debit_note_payload(docname: str, settings_name: str | None = None) -> 
 	if settings_name:
 		settings = get_settings(settings_name)
 		tpin = settings.get("tpin")
-		
-		
 
 	user = frappe.session.user or "admin"
 
@@ -348,8 +345,6 @@ def build_debit_note_payload(docname: str, settings_name: str | None = None) -> 
 	return payload
 
 
-
-
 @frappe.whitelist()
 def build_purchase_payload(docname: str, settings_name: str) -> dict:
 	# Fetch documents
@@ -457,7 +452,7 @@ def build_purchase_payload(docname: str, settings_name: str) -> dict:
 	return payload
 
 
-def generate_vsdc_item_payload(item_name: str,bhfid, settings_name: str) -> dict:
+def generate_vsdc_item_payload(item_name: str, bhfid, settings_name: str) -> dict:
 	item = frappe.get_doc("Item", item_name)
 
 	def get_code(fieldname: str) -> str | None:
@@ -546,17 +541,16 @@ def fmt4(value):
 
 def build_invoice_payload(invoice: "Document", settings_name: str) -> dict:
 	# settings = frappe.get_doc("Crystal ZRA Smart Invoice Settings", settings_name)
-	
+
 	settings = get_settings(settings_name)
 	tpin = settings.get("tpin")
-	branch_code = "000" 
+	branch_code = "000"
 	try:
 		if hasattr(invoice, "branch") and invoice.branch:
 			branch_doc = frappe.get_doc("Branch", invoice.branch)
 			branch_code = branch_doc.get("custom_branch_code") or "000"
 	except Exception as e:
 		frappe.log_error(f"Failed to fetch branch code: {e}", "Branch Code Error")
-
 
 	# Dates
 	sales_dt = datetime.strptime(str(invoice.posting_date), "%Y-%m-%d").strftime("%Y%m%d")
@@ -643,11 +637,7 @@ def build_invoice_payload(invoice: "Document", settings_name: str) -> dict:
 			or frappe.db.get_value("Item", item.item_code, "custom_smart_item_code")
 			or item.item_code
 		)
-		rrp = (
-			item.get("standard_rate")
-			or frappe.db.get_value("Item", item.item_code, "standard_rate")
-			
-		)
+		rrp = item.get("standard_rate") or frappe.db.get_value("Item", item.item_code, "standard_rate")
 		# Totals
 		tot_amt = fmt4(sply_amt - dc_amt + vat_amt)
 		tl_amt = tot_amt
@@ -687,7 +677,7 @@ def build_invoice_payload(invoice: "Document", settings_name: str) -> dict:
 				"dcRt": dc_rt,
 				"bcd": item.barcode or "",
 				"vatCatCd": vat_cat,
-				"rrp": rrp
+				"rrp": rrp,
 			}
 		)
 
@@ -731,14 +721,13 @@ def build_credit_note_payload(doc, settings_name):
 	settings = get_settings(settings_name)
 	tpin = settings.get("tpin")
 
-	branch_code = "000" 
+	branch_code = "000"
 	try:
 		if hasattr(original_invoice, "branch") and original_invoice.branch:
 			branch_doc = frappe.get_doc("Branch", original_invoice.branch)
 			branch_code = branch_doc.get("custom_branch_code") or "000"
 	except Exception as e:
 		frappe.log_error(f"Failed to fetch branch code: {e}", "Branch Code Error")
-
 
 	def extract_numeric(invoice_id: str) -> str:
 		"""
@@ -1208,42 +1197,45 @@ def build_sales_payload(sales_invoice_name, company_tpin, user="Admin"):
 
 	return payload
 
+
 def generate_custom_item_code_smart(doc: Document) -> str:
-    """
-    Generate smart item code in fixed format:
-        CC T PP QQ CCCC SSSSSSS
-        
-        CC  = Country (2 chars)
-        T   = Item type (1 char)
-        PP  = Packaging unit (2 chars)
-        QQ  = Qty unit (2 chars)
-        CCCC = Classification code (4 chars, padded)
-        SSSSSSS = Running sequence (7 digits)
-    """
+	"""
+	Generate smart item code in fixed format:
+	    CC T PP QQ CCCC SSSSSSS
 
-    # --- Extract fields ---
-    country = (doc.get("custom_smart_country_of_origin_") or "").upper().strip()[:2]
-    item_type = (doc.get("custom_smart_item_type") or "").upper().strip()[:1]
-    pkg_unit = (doc.get("custom_smart_packaging_unit") or "").upper().strip()[:2]
-    qty_unit = (doc.get("custom_smart_quantity_unit") or "").upper().strip()[:2]
-    class_code = (doc.get("custom_smart_item_classification_code") or "").strip()
+	    CC  = Country (2 chars)
+	    T   = Item type (1 char)
+	    PP  = Packaging unit (2 chars)
+	    QQ  = Qty unit (2 chars)
+	    CCCC = Classification code (4 chars, padded)
+	    SSSSSSS = Running sequence (7 digits)
+	"""
 
-    # --- Enforce padding ---
-    country = country.ljust(2)
-    item_type = item_type.ljust(1)
-    pkg_unit = pkg_unit.ljust(2)
-    qty_unit = qty_unit.ljust(2,)
-    class_code = class_code.zfill(4)  # always 4 digits
+	# --- Extract fields ---
+	country = (doc.get("custom_smart_country_of_origin_") or "").upper().strip()[:2]
+	item_type = (doc.get("custom_smart_item_type") or "").upper().strip()[:1]
+	pkg_unit = (doc.get("custom_smart_packaging_unit") or "").upper().strip()[:2]
+	qty_unit = (doc.get("custom_smart_quantity_unit") or "").upper().strip()[:2]
+	class_code = (doc.get("custom_smart_item_classification_code") or "").strip()
 
-    # --- Build prefix ---
-    prefix = f"{country}{item_type}{pkg_unit}{qty_unit}{class_code}"
+	# --- Enforce padding ---
+	country = country.ljust(2)
+	item_type = item_type.ljust(1)
+	pkg_unit = pkg_unit.ljust(2)
+	qty_unit = qty_unit.ljust(
+		2,
+	)
+	class_code = class_code.zfill(4)  # always 4 digits
 
-    # --- Determine suffix ---
-    if doc.get("custom_smart_item_code"):
-        suffix = doc.custom_smart_item_code[-7:]
-    else:
-        last = frappe.db.sql(
-            """
+	# --- Build prefix ---
+	prefix = f"{country}{item_type}{pkg_unit}{qty_unit}{class_code}"
+
+	# --- Determine suffix ---
+	if doc.get("custom_smart_item_code"):
+		suffix = doc.custom_smart_item_code[-7:]
+	else:
+		last = frappe.db.sql(
+			"""
             SELECT custom_smart_item_code
             FROM `tabItem`
             WHERE custom_smart_item_classification_code = %s
@@ -1251,66 +1243,65 @@ def generate_custom_item_code_smart(doc: Document) -> str:
             ORDER BY CAST(RIGHT(custom_smart_item_code, 7) AS UNSIGNED) DESC
             LIMIT 1
             """,
-            (doc.custom_smart_item_classification_code,),
-        )
+			(doc.custom_smart_item_classification_code,),
+		)
 
-        if last:
-            last_code = last[0][0]
-            try:
-                suffix = str(int(last_code[-7:]) + 1).zfill(7)
-            except:
-                suffix = "0000001"
-        else:
-            suffix = "0000001"
+		if last:
+			last_code = last[0][0]
+			try:
+				suffix = str(int(last_code[-7:]) + 1).zfill(7)
+			except:
+				suffix = "0000001"
+		else:
+			suffix = "0000001"
 
-    # --- Final smart code ---
-    new_code = f"{prefix}{suffix}"
+	# --- Final smart code ---
+	new_code = f"{prefix}{suffix}"
 
-    # Save
-    doc.db_set("custom_smart_item_code", new_code, update_modified=False)
+	# Save
+	doc.db_set("custom_smart_item_code", new_code, update_modified=False)
 
-    frappe.logger().info(f"[SMART] Generated Smart Code: {new_code}")
+	frappe.logger().info(f"[SMART] Generated Smart Code: {new_code}")
 
-    return new_code
-
+	return new_code
 
 
 def build_import_item_payload(settings: dict):
-	return {"company_name": settings.company, "tpin": settings.tpin, "bhfId": settings.get("bhf_id", "000")}
+	return {"company_name": settings.company, "tpin": settings.tpin}
 
 
 def get_branch_code_from_sle(sle: dict) -> str:
-    """Return branch code from the document that generated the SLE."""
+	"""Return branch code from the document that generated the SLE."""
 
-    voucher_type = sle.get("voucher_type")
-    voucher_no = sle.get("voucher_no")
+	voucher_type = sle.get("voucher_type")
+	voucher_no = sle.get("voucher_no")
 
-    if not voucher_type or not voucher_no:
-        return "001"
+	if not voucher_type or not voucher_no:
+		return "001"
 
-    if not frappe.db.exists(voucher_type, voucher_no):
-        return "001"
+	if not frappe.db.exists(voucher_type, voucher_no):
+		return "001"
 
-    doc = frappe.get_doc(voucher_type, voucher_no)
+	doc = frappe.get_doc(voucher_type, voucher_no)
 
-    # Branch may appear under different fieldnames
-    branch_name = (
-        getattr(doc, "branch", None)
-        or getattr(doc, "custom_branch", None)
-        or getattr(doc, "branch_id", None)
-        or None
-    )
+	# Branch may appear under different fieldnames
+	branch_name = (
+		getattr(doc, "branch", None)
+		or getattr(doc, "custom_branch", None)
+		or getattr(doc, "branch_id", None)
+		or None
+	)
 
-    if not branch_name:
-        return "001"
+	if not branch_name:
+		return "001"
 
-    # Fetch Branch master to get ZRA branch code
-    branch_doc = frappe.get_doc("Branch", branch_name)
+	# Fetch Branch master to get ZRA branch code
+	branch_doc = frappe.get_doc("Branch", branch_name)
 
-    branch_code = (
-        getattr(branch_doc, "custom_branch_code", None)
-        or getattr(branch_doc, "custom_branch_code", None)
-        or "001"
-    )
+	branch_code = (
+		getattr(branch_doc, "custom_branch_code", None)
+		or getattr(branch_doc, "custom_branch_code", None)
+		or "001"
+	)
 
-    return str(branch_code).zfill(3)
+	return str(branch_code).zfill(3)


### PR DESCRIPTION
This commit introduces branch-specific import item selection and adds branch code tracking throughout the import and purchase invoice workflow.

API Changes:
- Rename select_import_items_all_branches() to select_import_items()
- Add branch code (bhfId) to import item request payload
- Pass branch code through perform_import_item() to handler
- Rename create_items_from_fetched_registered_imports() to create_item_from_fetched_registered_import() for consistency

Purchase Invoice:
- Add branch lookup from branch_code when creating purchase invoices
- Set branch field on Purchase Invoice document from branch_code

Data Model:
- Add branch_code field to Crystallised Smart Registered Import Item doctype
- Store branch_code in imported item documents from API response

UI Updates:
- Add branch selection field to import item fetch dialog
- Pass branch_name parameter to select_import_items_all_branches API
- Include branch_code in purchase invoice creation request