### PR TITLE
hotfix:purchase-id-generation-fix

### DIFF
--- a/ca_erpnext_zra/ca_erpnext_zra/handlers/purchase_handlers.py
+++ b/ca_erpnext_zra/ca_erpnext_zra/handlers/purchase_handlers.py
@@ -60,15 +60,15 @@ def create_purchase_from_smart_search_details(fetched_purchase: dict, branch=Non
 	Returns the Document object if save_and_submit=False, otherwise returns document name.
 	"""
 
-	# Create a more unique purchase_id that includes date and amount to avoid false duplicates
+	# Create a more unique purchase_id that includes date to avoid false duplicates
 	supplier_tpin = fetched_purchase.get('spplrTpin', 'UNKNOWN')
 	supplier_branch = fetched_purchase.get('spplrBhfId', '000')
 	invoice_no = fetched_purchase.get('spplrInvcNo', '0')
 	sales_date = fetched_purchase.get('salesDt', '')
 	total_amount = fetched_purchase.get('totAmt', 0)
 	
-	# Include sales date and total amount to make it more unique
-	purchase_id = f"{supplier_tpin}-{supplier_branch}-{invoice_no}-{sales_date}-{total_amount}"
+	# Include sales date to make it  unique
+	purchase_id = f"{supplier_tpin}-{supplier_branch}-{invoice_no}-{sales_date}"
 
 	existing_doc = frappe.get_value(REGISTERED_PURCHASES_DOCTYPE_NAME, {"purchase_id": purchase_id}, "name")
 


### PR DESCRIPTION
Summary

This PR fixes the issue of excessively long purchase_ids. Previously, the purchase-id included supplier details, invoice number, sales date, and amount resulting in unnecessarily long strings that were cumbersome to handle and search.

Changes

Removed the total_amount field from the purchase_id generation logic.

The ID is now generated as:

purchase_id = f"{supplier_tpin}-{supplier_branch}-{invoice_no}-{sales_date}"

Uniqueness is preserved through the combination of supplier, branch, invoice, and date without redundant length.

Impact

Shorter, cleaner purchase_id values are easier to read and reference.

Improved usability when searching or filtering purchases in the system.
