### PR TITLE
not saved dirty state

### DIFF
--- a/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.js
+++ b/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.js
@@ -17,8 +17,10 @@ frappe.ui.form.on(doctypeName, {
             frm.set_value("payment_type_code", "01");
             frm.set_value("payment_type", "Cash");
         } else {
-            // For EXISTING forms: Load ZRA smart purchase items
-            load_zra_smart_purchase_items(frm);
+            // Only load ZRA items if they are not already populated to avoid marking form as "Not Saved"
+            if (!frm.doc.items || frm.doc.items.length === 0) {
+                load_zra_smart_purchase_items(frm);
+            }
         }
 
         // Setup standard Link field queries for supplier and branch fields
@@ -49,31 +51,6 @@ frappe.ui.form.on(doctypeName, {
             });
         }
 
-        // Registration Type field change handler
-        frm.fields_dict.registration_type.$input.on("change", function () {
-            update_registration_type_codes(frm);
-        });
-
-        // Purchase Type field change handler
-        frm.fields_dict.purchase_type.$input.on("change", function () {
-            update_purchase_type_codes(frm);
-        });
-
-        // Purchase Status field change handler
-        frm.fields_dict.purchase_status.$input.on("change", function () {
-            update_purchase_status_codes(frm);
-        });
-
-        // Payment Type field change handler
-        frm.fields_dict.payment_type.$input.on("change", function () {
-            update_payment_type_codes(frm);
-        });
-
-        // Receipt Type field change handler
-        frm.fields_dict.receipt_type.$input.on("change", function () {
-            update_receipt_type_codes(frm);
-        });
-
         // Setup item query for item_code field in items table
         setup_item_query(frm);
 
@@ -82,13 +59,13 @@ frappe.ui.form.on(doctypeName, {
 
         // Setup Clear Link button handlers
         setup_clear_link_handlers(frm);
-        
+
         // Setup grid event listeners for item deletion
         setup_grid_event_listeners(frm);
 
         // Show item filtering status
         show_item_filtering_status(frm);
-        
+
         // Monitor items array for changes (including deletions)
         monitor_items_changes(frm);
 
@@ -457,10 +434,10 @@ frappe.ui.form.on(doctypeName, {
 
     items_remove: function (frm, cdt, cdn) {
         // Multiple approaches to ensure totals are recalculated when items are deleted
-        
+
         // Approach 1: Immediate recalculation
         calculate_totals(frm);
-        
+
         // Approach 2: Delayed recalculation with multiple timeouts
         setTimeout(() => {
             calculate_totals(frm);
@@ -469,12 +446,12 @@ frappe.ui.form.on(doctypeName, {
             frm.refresh_field("total_tax_amount");
             frm.refresh_field("total_item_count");
         }, 50);
-        
+
         setTimeout(() => {
             calculate_totals(frm);
             frm.refresh_field("items");
         }, 200);
-        
+
         setTimeout(() => {
             calculate_totals(frm);
             frm.dirty();
@@ -482,16 +459,16 @@ frappe.ui.form.on(doctypeName, {
     },
 
     // Add before_items_remove event
-    before_items_remove: function(frm, cdt, cdn) {
+    before_items_remove: function (frm, cdt, cdn) {
         // This fires before the item is actually removed
         setTimeout(() => {
             calculate_totals(frm);
         }, 100);
     },
 
-    after_save: function (frm) {},
+    after_save: function (frm) { },
 
-    onload_post_render: function(frm) {
+    onload_post_render: function (frm) {
         // Additional setup after form is fully rendered
         setTimeout(() => {
             setup_grid_event_listeners(frm);
@@ -577,7 +554,7 @@ frappe.ui.form.on("Smart Registered Purchase Item", {
         }
     },
 
-    form_render: function (frm, cdt, cdn) {}
+    form_render: function (frm, cdt, cdn) { }
 });
 
 // ============================================================
@@ -642,7 +619,7 @@ function fetch_item_details(frm, row) {
             try {
                 // Re-fetch the row to ensure it still exists
                 const current_row = frappe.get_doc(row.doctype, row.name);
-                
+
                 if (response.message && current_row && !current_row.__islocal_deleted) {
                     const item = response.message;
 
@@ -855,10 +832,10 @@ function setup_grid_event_listeners(frm) {
     setTimeout(() => {
         if (frm.fields_dict.items && frm.fields_dict.items.grid) {
             const grid = frm.fields_dict.items.grid;
-            
+
             // Listen for row removal events
             $(grid.wrapper).off('click.delete_row');
-            $(grid.wrapper).on('click.delete_row', '.grid-delete-row', function() {
+            $(grid.wrapper).on('click.delete_row', '.grid-delete-row', function () {
                 // Delay calculation to ensure row is removed
                 setTimeout(() => {
                     calculate_totals(frm);
@@ -868,19 +845,19 @@ function setup_grid_event_listeners(frm) {
                     frm.refresh_field("total_item_count");
                 }, 200);
             });
-            
+
             // Listen for any grid changes
             $(grid.wrapper).off('change.grid_totals');
-            $(grid.wrapper).on('change.grid_totals', function() {
+            $(grid.wrapper).on('change.grid_totals', function () {
                 setTimeout(() => {
                     calculate_totals(frm);
                 }, 100);
             });
-            
+
             // Override the grid's remove_row method
             if (grid.remove_row) {
                 const original_remove_row = grid.remove_row;
-                grid.remove_row = function(idx) {
+                grid.remove_row = function (idx) {
                     const result = original_remove_row.call(this, idx);
                     // Recalculate after removal
                     setTimeout(() => {
@@ -901,7 +878,7 @@ function setup_grid_event_listeners(frm) {
 function monitor_items_changes(frm) {
     // Store initial items count
     let previous_items_count = frm.doc.items ? frm.doc.items.length : 0;
-    
+
     // Set up interval to check for changes
     const monitor_interval = setInterval(() => {
         if (!frm.doc || frm.doc.__islocal === 0) {
@@ -909,11 +886,11 @@ function monitor_items_changes(frm) {
             clearInterval(monitor_interval);
             return;
         }
-        
-        const current_items_count = frm.doc.items ? frm.doc.items.filter(item => 
+
+        const current_items_count = frm.doc.items ? frm.doc.items.filter(item =>
             item && !item.__islocal_deleted && !item.__deleted && item.item_code
         ).length : 0;
-        
+
         if (current_items_count !== previous_items_count) {
             // Items count changed, recalculate totals
             calculate_totals(frm);
@@ -921,11 +898,11 @@ function monitor_items_changes(frm) {
             frm.refresh_field("total_taxable_amount");
             frm.refresh_field("total_tax_amount");
             frm.refresh_field("total_item_count");
-            
+
             previous_items_count = current_items_count;
         }
     }, 500); // Check every 500ms
-    
+
     // Store interval ID on form for cleanup
     frm._items_monitor_interval = monitor_interval;
 }
@@ -1659,12 +1636,12 @@ function calculate_item_row_safe(frm, row) {
     if (!row || typeof row !== 'object') {
         return;
     }
-    
+
     // Check if row is marked for deletion
     if (row.__islocal_deleted || row.__deleted) {
         return;
     }
-    
+
     // Check if row has minimum required properties
     if (!row.hasOwnProperty('name') && !row.hasOwnProperty('idx')) {
         return;
@@ -1771,9 +1748,9 @@ function calculate_totals(frm) {
     let total_item_count = 0;
 
     // Filter out null/undefined items, deleted items, and items marked for deletion
-    const validItems = frm.doc.items.filter(item => 
-        item && 
-        !item.__islocal_deleted && 
+    const validItems = frm.doc.items.filter(item =>
+        item &&
+        !item.__islocal_deleted &&
         !item.__deleted &&
         item.item_code // Must have an item code to be valid
     );
@@ -1819,44 +1796,64 @@ function format_currency(value, currency) {
 // Function to update registration type codes
 function update_registration_type_codes(frm) {
     let registration_type = frm.doc.registration_type;
+    let target_val = "";
     if (registration_type === "Manual") {
-        frm.set_value("regtycd", "M");
+        target_val = "M";
     } else if (registration_type === "Automatic") {
-        frm.set_value("regtycd", "A");
+        target_val = "A";
+    }
+
+    if (target_val && frm.doc.regtycd !== target_val) {
+        frm.set_value("regtycd", target_val);
     }
 }
 
 // Function to update purchase type codes
 function update_purchase_type_codes(frm) {
     let purchase_type = frm.doc.purchase_type;
+    let target_val = "";
     if (purchase_type === "Normal") {
-        frm.set_value("pchstycd", "N");
+        target_val = "N";
     } else if (purchase_type === "Copy") {
-        frm.set_value("pchstycd", "C");
+        target_val = "C";
+    }
+
+    if (target_val && frm.doc.pchstycd !== target_val) {
+        frm.set_value("pchstycd", target_val);
     }
 }
 
 // Function to update receipt type codes
 function update_receipt_type_codes(frm) {
     let receipt_type = frm.doc.receipt_type;
+    let target_val = "";
     if (receipt_type === "Purchase") {
-        frm.set_value("receipt_type_code", "P");
+        target_val = "P";
     } else if (receipt_type === "Refund after Purchase") {
-        frm.set_value("receipt_type_code", "R");
+        target_val = "R";
+    }
+
+    if (target_val && frm.doc.receipt_type_code !== target_val) {
+        frm.set_value("receipt_type_code", target_val);
     }
 }
 
 // Function to update purchase status codes
 function update_purchase_status_codes(frm) {
     let purchase_status = frm.doc.purchase_status;
+    let target_val = "";
     if (purchase_status === "Refunded") {
-        frm.set_value("pchssttscd", "05");
+        target_val = "05";
     } else if (purchase_status === "Transferred") {
-        frm.set_value("pchssttscd", "06");
+        target_val = "06";
     } else if (purchase_status === "Approved") {
-        frm.set_value("pchssttscd", "02");
+        target_val = "02";
     } else if (purchase_status === "Rejected") {
-        frm.set_value("pchssttscd", "04");
+        target_val = "04";
+    }
+
+    if (target_val && frm.doc.pchssttscd !== target_val) {
+        frm.set_value("pchssttscd", target_val);
     }
 }
 
@@ -1874,8 +1871,9 @@ function update_payment_type_codes(frm) {
         "Bank transfer": "08",
     };
 
-    if (paymentTypeMap[payment_type]) {
-        frm.set_value("payment_type_code", paymentTypeMap[payment_type]);
+    let target_val = paymentTypeMap[payment_type];
+    if (target_val && frm.doc.payment_type_code !== target_val) {
+        frm.set_value("payment_type_code", target_val);
     }
 }
 


### PR DESCRIPTION
# PR Description: Smart Purchases UI and Data Persistence Fixes

This Pull Request addresses critical UI errors and data persistence issues in the `Crystallised ZRA Smart Purchases` DocType.

## Issues Addressed

### 1. TypeError: Cannot read properties of undefined (reading 'on')
- **Description**: An uncaught error was occurring in the [refresh](cci:1://file://wsl.localhost/Ubuntu/home/marty/frappe-bench/apps/ca_erpnext_zra/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.js:29:4-303:5) hook, preventing subsequent form logic from executing.
- **Cause**: Manual jQuery event listeners were being attached to field inputs before they were guaranteed to be rendered or when they were hidden.
- **Fix**: Removed redundant manual listeners. These fields are already correctly managed by Frappe's standard form field handlers.

### 2. "Not Saved" State Triggered on Refresh
- **Description**: Documents would incorrectly enter a "Not Saved" state immediately upon loading or refreshing, even when no changes were made.
- **Cause 1**: The [onload](cci:1://file://wsl.localhost/Ubuntu/home/marty/frappe-bench/apps/ca_erpnext_zra/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.js:5:4-27:5) hook was unconditionally triggering [load_zra_smart_purchase_items](cci:1://file://wsl.localhost/Ubuntu/home/marty/frappe-bench/apps/ca_erpnext_zra/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.js:1565:0-1626:1) for existing documents, which cleared and re-populated the items table.
- **Cause 2**: Helper functions for code updates called `frm.set_value` on every refresh without checking for actual value changes.
- **Fix**:
    - Restricted item re-loading in [onload](cci:1://file://wsl.localhost/Ubuntu/home/marty/frappe-bench/apps/ca_erpnext_zra/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.js:5:4-27:5) to documents with empty item tables.
    - Optimized helper functions to only call `frm.set_value` if the underlying value has actually changed.

## Changes
- **File**: [crystallised_zra_smart_purchases.js](cci:7://file://wsl.localhost/Ubuntu/home/marty/frappe-bench/apps/ca_erpnext_zra/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.js:0:0-0:0)
- Removed manual `.on("change", ...)` listeners in [refresh](cci:1://file://wsl.localhost/Ubuntu/home/marty/frappe-bench/apps/ca_erpnext_zra/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.js:29:4-303:5).
- Added conditional check in [onload](cci:1://file://wsl.localhost/Ubuntu/home/marty/frappe-bench/apps/ca_erpnext_zra/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.js:5:4-27:5) for [load_zra_smart_purchase_items](cci:1://file://wsl.localhost/Ubuntu/home/marty/frappe-bench/apps/ca_erpnext_zra/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.js:1565:0-1626:1).
- Refactored [update_registration_type_codes](cci:1://file://wsl.localhost/Ubuntu/home/marty/frappe-bench/apps/ca_erpnext_zra/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.js:1795:0-1808:1), [update_purchase_type_codes](cci:1://file://wsl.localhost/Ubuntu/home/marty/frappe-bench/apps/ca_erpnext_zra/ca_erpnext_zra/ca_erpnext_zra/doctype/crystallised_zra_smart_purchases/crystallised_zra_smart_purchases.js:1810:0-1823:1), etc., to include change detection.